### PR TITLE
fast_dev_run parameter for pipeline 

### DIFF
--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -332,8 +332,10 @@ class Pipeline:
         # document.
         model_inputs = self.preprocess(documents, **preprocess_params)
         if forward_params.pop("fast_dev_run", False):
-            warnings.warn("Execute a fast dev run, only the first model input will be processed.")
-            model_inputs = model_inputs[:1]
+            warnings.warn(
+                "Execute a fast dev run, only the first two model inputs will be processed."
+            )
+            model_inputs = model_inputs[:2]
         # Create a dataloader from the model inputs. This uses taskmodule.collate().
         dataloader = self.get_dataloader(model_inputs=model_inputs, **dataloader_params)
 

--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -182,7 +182,7 @@ class Pipeline:
             preprocess_parameters["predict_field"] = field
 
         # set forward parameters
-        for p_name in ["show_progress_bar"]:
+        for p_name in ["show_progress_bar", "fast_dev_run"]:
             if p_name in pipeline_parameters:
                 forward_parameters[p_name] = pipeline_parameters[p_name]
 
@@ -331,6 +331,9 @@ class Pipeline:
         # This creates encodings from the documents. It modifies the documents and may produce multiple entries per
         # document.
         model_inputs = self.preprocess(documents, **preprocess_params)
+        if forward_params.pop("fast_dev_run", False):
+            warnings.warn("Execute a fast dev run, only the first model input will be processed.")
+            model_inputs = model_inputs[:1]
         # Create a dataloader from the model inputs. This uses taskmodule.collate().
         dataloader = self.get_dataloader(model_inputs=model_inputs, **dataloader_params)
 

--- a/tests/pipeline/test_ner_span_classification.py
+++ b/tests/pipeline/test_ner_span_classification.py
@@ -22,7 +22,9 @@ def test_ner_span_classification(fast_dev_run):
     ner_taskmodule = TransformerSpanClassificationTaskModule.from_pretrained(model_name_or_path)
     ner_model = TransformerSpanClassificationModel.from_pretrained(model_name_or_path)
 
-    ner_pipeline = Pipeline(model=ner_model, taskmodule=ner_taskmodule, device=-1, fast_dev_run=fast_dev_run)
+    ner_pipeline = Pipeline(
+        model=ner_model, taskmodule=ner_taskmodule, device=-1, fast_dev_run=fast_dev_run
+    )
 
     document0 = ExampleDocument(
         "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."

--- a/tests/pipeline/test_ner_span_classification.py
+++ b/tests/pipeline/test_ner_span_classification.py
@@ -26,18 +26,13 @@ def test_ner_span_classification(fast_dev_run):
         model=ner_model, taskmodule=ner_taskmodule, device=-1, fast_dev_run=fast_dev_run
     )
 
-    document0 = ExampleDocument(
-        "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
-    )
-    document1 = ExampleDocument(
-        "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
-    )
-    documents = [document0, document1]
+    text = "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
+    documents = [ExampleDocument(text), ExampleDocument(text), ExampleDocument(text)]
     ner_pipeline(documents, predict_field="entities", batch_size=2)
 
     for i, document in enumerate(documents):
         entities = document.entities.predictions
-        if i > 0 and fast_dev_run:
+        if i > 1 and fast_dev_run:
             assert len(entities) == 0
             continue
         assert len(entities) == 3


### PR DESCRIPTION
This adds a boolean parameter `fast_dev_run` to the pipeline that allows for similar functionality as the one for training with pytorch-lightning: If enabled, only the first model inputs, i.e the first entry produced by `taskmodule.encode`, will be processed. This is especially useful for cli tests in downstream projects to check if a pipeline runs through without the need to prepare a special dummy dataset.

Note: I successfully ran `tests_no_local_datasets-3.9` locally.