### PR TITLE
[WIP] is_prepared attribute for taskmodule

### DIFF
--- a/src/pytorch_ie/core/__init__.py
+++ b/src/pytorch_ie/core/__init__.py
@@ -1,3 +1,3 @@
 from .document import Annotation, AnnotationList, Document, annotation_field
 from .model import PyTorchIEModel
-from .taskmodule import TaskEncoding, TaskModule
+from .taskmodule import TaskEncoding, TaskModule, taskmodule_init

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -155,7 +155,9 @@ class TaskModule(
         TaskOutput,
     ],
 ):
-    def __init__(self, encode_document_batch_size: Optional[int] = None, is_prepared: bool = False, **kwargs):
+    def __init__(
+        self, encode_document_batch_size: Optional[int] = None, is_prepared: bool = False, **kwargs
+    ):
         super().__init__(**kwargs)
         self.is_prepared = is_prepared
         self.encode_document_batch_size = encode_document_batch_size

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -167,6 +167,7 @@ class TaskModule(
         config["taskmodule_type"] = (
             registered_name if registered_name is not None else this_class.__name__
         )
+        config["is_prepared"] = self.is_prepared
         return config
 
     def _prepare(self, documents: Sequence[DocumentType]) -> None:

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -155,8 +155,9 @@ class TaskModule(
         TaskOutput,
     ],
 ):
-    def __init__(self, encode_document_batch_size: Optional[int] = None, **kwargs):
+    def __init__(self, encode_document_batch_size: Optional[int] = None, is_prepared: bool = False, **kwargs):
         super().__init__(**kwargs)
+        self.is_prepared = is_prepared
         self.encode_document_batch_size = encode_document_batch_size
 
     def _config(self) -> Dict[str, Any]:
@@ -168,7 +169,14 @@ class TaskModule(
         )
         return config
 
+    def _prepare(self, documents: Sequence[DocumentType]) -> None:
+        return None
+
     def prepare(self, documents: Sequence[DocumentType]) -> None:
+        if self.is_prepared:
+            raise Exception("The taskmodule is already prepared, it can not be prepared again.")
+        self._prepare(documents=documents)
+        self.is_prepared = True
         return None
 
     def batch_encode(

--- a/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
@@ -176,10 +176,13 @@ class TransformerRETextClassificationTaskModule(_TransformerReTextClassification
 
         self.argument_markers = None
 
-        if self.is_prepared():
+        if self.is_prepared:
+            assert (
+                self.entity_labels is not None
+            ), f"No entity labels available, was `prepare` called correctly?"
             self.argument_markers = _create_argument_markers(
                 # ignore typing because is_prepared already checks that entity_labels is not None
-                entity_labels=self.entity_labels,  # type: ignore
+                entity_labels=self.entity_labels,
                 add_type_to_marker=self.add_type_to_marker,
             )
             # do not sort here to keep order from loaded taskmodule config
@@ -191,15 +194,7 @@ class TransformerRETextClassificationTaskModule(_TransformerReTextClassification
         config["entity_labels"] = self.entity_labels
         return config
 
-    def is_prepared(self):
-        """
-        This should return True iff all config entries added by the _config() method are available.
-        By doing so, it marks the taskmodule ready to save with save_pretrained(), i.e. that the
-        exact same taskmodule will be produced when loaded again via from_pretrained().
-        """
-        return self.entity_labels is not None and self.label_to_id is not None
-
-    def prepare(self, documents: Sequence[TextDocument]) -> None:
+    def _prepare(self, documents: Sequence[TextDocument]) -> None:
         entity_labels: Set[str] = set()
         relation_labels: Set[str] = set()
         for document in documents:

--- a/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
@@ -194,6 +194,9 @@ class TransformerRETextClassificationTaskModule(_TransformerReTextClassification
         config["entity_labels"] = self.entity_labels
         return config
 
+    def _is_prepared(self):
+        return self.label_to_id is not None and self.entity_labels is not None
+
     def _prepare(self, documents: Sequence[TextDocument]) -> None:
         entity_labels: Set[str] = set()
         relation_labels: Set[str] = set()

--- a/src/pytorch_ie/taskmodules/transformer_seq2seq.py
+++ b/src/pytorch_ie/taskmodules/transformer_seq2seq.py
@@ -7,7 +7,7 @@ from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import TruncationStrategy
 
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
-from pytorch_ie.core import Annotation, TaskEncoding, TaskModule
+from pytorch_ie.core import Annotation, TaskEncoding, TaskModule, taskmodule_init
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models import (
     TransformerSeq2SeqModelBatchOutput,
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 @TaskModule.register()
 class TransformerSeq2SeqTaskModule(_TransformerSeq2SeqTaskModule):
+    @taskmodule_init()
     def __init__(
         self,
         tokenizer_name_or_path: str,

--- a/src/pytorch_ie/taskmodules/transformer_span_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_span_classification.py
@@ -92,7 +92,7 @@ class TransformerSpanClassificationTaskModule(_TransformerSpanClassificationTask
         config["label_to_id"] = self.label_to_id
         return config
 
-    def prepare(self, documents: Sequence[TextDocument]) -> None:
+    def _prepare(self, documents: Sequence[TextDocument]) -> None:
         labels: Set[str] = set()
         for document in documents:
             entities: Union[Sequence[LabeledSpan], Sequence[MultiLabeledSpan]] = document[

--- a/src/pytorch_ie/taskmodules/transformer_span_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_span_classification.py
@@ -9,7 +9,7 @@ from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import BatchEncoding, TruncationStrategy
 
 from pytorch_ie.annotations import LabeledSpan, MultiLabeledSpan, Span
-from pytorch_ie.core import TaskEncoding, TaskModule
+from pytorch_ie.core import TaskEncoding, TaskModule, taskmodule_init
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models.transformer_span_classification import (
     TransformerSpanClassificationModelBatchOutput,
@@ -51,6 +51,7 @@ logger = logging.getLogger(__name__)
 
 @TaskModule.register()
 class TransformerSpanClassificationTaskModule(_TransformerSpanClassificationTaskModule):
+    @taskmodule_init(require_preparation=["label_to_id"])
     def __init__(
         self,
         tokenizer_name_or_path: str,
@@ -85,14 +86,6 @@ class TransformerSpanClassificationTaskModule(_TransformerSpanClassificationTask
         self.pad_to_multiple_of = pad_to_multiple_of
         self.label_pad_token_id = label_pad_token_id
         self.multi_label = multi_label
-
-    def _config(self) -> Dict[str, Any]:
-        config = super()._config()
-        config["label_to_id"] = self.label_to_id
-        return config
-
-    def _is_prepared(self):
-        return self.label_to_id is not None
 
     def _prepare(self, documents: Sequence[TextDocument]) -> None:
         labels: Set[str] = set()

--- a/src/pytorch_ie/taskmodules/transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_text_classification.py
@@ -110,7 +110,7 @@ class TransformerTextClassificationTaskModule(_TransformerTextClassificationTask
         config["label_to_id"] = self.label_to_id
         return config
 
-    def prepare(self, documents: Sequence[TextDocument]) -> None:
+    def _prepare(self, documents: Sequence[TextDocument]) -> None:
         labels = set()
         for document in documents:
             annotations: Sequence[Label] = document[self.annotation]

--- a/src/pytorch_ie/taskmodules/transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_text_classification.py
@@ -18,7 +18,7 @@ from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import TruncationStrategy
 
 from pytorch_ie.annotations import Label, MultiLabel
-from pytorch_ie.core import TaskEncoding, TaskModule
+from pytorch_ie.core import TaskEncoding, TaskModule, taskmodule_init
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models.transformer_text_classification import (
     TransformerTextClassificationModelBatchOutput,
@@ -72,6 +72,7 @@ _TransformerTextClassificationTaskModule = TaskModule[
 
 @TaskModule.register()
 class TransformerTextClassificationTaskModule(_TransformerTextClassificationTaskModule):
+    @taskmodule_init(require_preparation=["label_to_id"])
     def __init__(
         self,
         tokenizer_name_or_path: str,
@@ -103,14 +104,6 @@ class TransformerTextClassificationTaskModule(_TransformerTextClassificationTask
         self.max_length = max_length
         self.pad_to_multiple_of = pad_to_multiple_of
         self.multi_label = multi_label
-
-    def _config(self) -> Dict[str, Any]:
-        config = super()._config()
-        config["label_to_id"] = self.label_to_id
-        return config
-
-    def _is_prepared(self):
-        return self.label_to_id is not None
 
     def _prepare(self, documents: Sequence[TextDocument]) -> None:
         labels = set()

--- a/src/pytorch_ie/taskmodules/transformer_token_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_token_classification.py
@@ -9,7 +9,7 @@ from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import BatchEncoding, TruncationStrategy
 
 from pytorch_ie.annotations import LabeledSpan, Span
-from pytorch_ie.core import TaskEncoding, TaskModule
+from pytorch_ie.core import TaskEncoding, TaskModule, taskmodule_init
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models.transformer_token_classification import (
     TransformerTokenClassificationModelBatchOutput,
@@ -57,6 +57,7 @@ logger = logging.getLogger(__name__)
 
 @TaskModule.register()
 class TransformerTokenClassificationTaskModule(_TransformerTokenClassificationTaskModule):
+    @taskmodule_init(require_preparation=["label_to_id"])
     def __init__(
         self,
         tokenizer_name_or_path: str,
@@ -90,14 +91,6 @@ class TransformerTokenClassificationTaskModule(_TransformerTokenClassificationTa
         self.window_overlap = window_overlap
         self.show_statistics = show_statistics
         self.include_ill_formed_predictions = include_ill_formed_predictions
-
-    def _config(self) -> Dict[str, Any]:
-        config = super()._config()
-        config["label_to_id"] = self.label_to_id
-        return config
-
-    def _is_prepared(self):
-        return self.label_to_id is not None
 
     def _prepare(self, documents: Sequence[TextDocument]) -> None:
         labels = set()

--- a/src/pytorch_ie/taskmodules/transformer_token_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_token_classification.py
@@ -97,7 +97,7 @@ class TransformerTokenClassificationTaskModule(_TransformerTokenClassificationTa
         config["label_to_id"] = self.label_to_id
         return config
 
-    def prepare(self, documents: Sequence[TextDocument]) -> None:
+    def _prepare(self, documents: Sequence[TextDocument]) -> None:
         labels = set()
         for document in documents:
             entities: Sequence[LabeledSpan] = document[self.entity_annotation]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,6 @@ def json_dataset_to_prepare():
 
 @pytest.fixture(scope="module")
 def dataset_to_prepare(json_dataset_to_prepare):
-
     mapped_dataset = json_dataset_to_prepare.map(example_to_doc_dict)
 
     dataset = datasets.DatasetDict(

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -183,8 +183,7 @@ def test_dataset_map_with_result_document_type(maybe_iterable_dataset, infer_typ
 @pytest.mark.parametrize("inplace", [False, True])
 @pytest.mark.parametrize("as_dataset", [False, True])
 def test_dataset_with_taskmodule(
-    maybe_iterable_dataset, taskmodule_prepared, model_output, encode_target, inplace
-, as_dataset
+    maybe_iterable_dataset, taskmodule_prepared, model_output, encode_target, inplace, as_dataset
 ):
     train_dataset = maybe_iterable_dataset["train"]
 

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -32,9 +32,7 @@ def taskmodule():
 def taskmodule_prepared(dataset_to_prepare, taskmodule):
     train_dataset = dataset_to_prepare["train"]
     taskmodule.prepare(train_dataset)
-    assert set(taskmodule.label_to_id.keys()) == {"PER", "ORG", "O"}
-    assert [taskmodule.id_to_label[i] for i in range(3)] == ["O", "ORG", "PER"]
-    assert taskmodule.label_to_id["O"] == 0
+    assert taskmodule.label_to_id == {"O": 0, "ORG": 1, "PER": 2}
     return taskmodule
 
 

--- a/tests/models/test_transformer_span_classification.py
+++ b/tests/models/test_transformer_span_classification.py
@@ -18,9 +18,9 @@ def taskmodule():
     return taskmodule
 
 
-@pytest.fixture
-def prepared_taskmodule(taskmodule, documents):
-    taskmodule.prepare(documents)
+@pytest.fixture(scope="module")
+def prepared_taskmodule(taskmodule, documents_to_prepare):
+    taskmodule.prepare(documents_to_prepare)
     return taskmodule
 
 

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -5,7 +5,6 @@ import pytest
 import torch
 
 from pytorch_ie.taskmodules import TransformerRETextClassificationTaskModule
-from pytorch_ie.taskmodules.transformer_re_text_classification import _enumerate_entity_pairs
 
 
 @pytest.fixture(scope="module")
@@ -28,16 +27,26 @@ def taskmodule_optional_marker(request):
     return taskmodule
 
 
-@pytest.fixture
-def prepared_taskmodule(taskmodule, documents):
-    taskmodule.prepare(documents)
+@pytest.fixture(scope="module")
+def prepared_taskmodule(documents_to_prepare):
+    tokenizer_name_or_path = "bert-base-cased"
+    taskmodule = TransformerRETextClassificationTaskModule(
+        tokenizer_name_or_path=tokenizer_name_or_path
+    )
+
+    taskmodule.prepare(documents_to_prepare)
     return taskmodule
 
 
-@pytest.fixture
-def prepared_taskmodule_optional_marker(taskmodule_optional_marker, documents):
-    taskmodule_optional_marker.prepare(documents)
-    return taskmodule_optional_marker
+@pytest.fixture(scope="module", params=[False, True])
+def prepared_taskmodule_optional_marker(documents_to_prepare, request):
+    tokenizer_name_or_path = "bert-base-cased"
+    taskmodule = TransformerRETextClassificationTaskModule(
+        tokenizer_name_or_path=tokenizer_name_or_path, add_type_to_marker=request.param
+    )
+
+    taskmodule.prepare(documents_to_prepare)
+    return taskmodule
 
 
 @pytest.fixture
@@ -63,9 +72,9 @@ def model_output():
 
 def test_prepare(taskmodule_optional_marker, documents):
     taskmodule = taskmodule_optional_marker
-    assert not taskmodule.is_prepared()
+    assert not taskmodule.is_prepared
     taskmodule.prepare(documents)
-    assert taskmodule.is_prepared()
+    assert taskmodule.is_prepared
 
     if taskmodule.add_type_to_marker:
         assert taskmodule.entity_labels == ["ORG", "PER"]

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -98,19 +98,12 @@ def test_prepare(taskmodule_optional_marker, documents):
             ("tail", "end"): "[/T]",
         }
 
-    assert set(taskmodule.label_to_id.keys()) == {
-        taskmodule.none_label,
-        "per:employee_of",
-        "org:founded_by",
-        "per:founder",
+    assert taskmodule.label_to_id == {
+        taskmodule.none_label: 0,
+        "org:founded_by": 1,
+        "per:employee_of": 2,
+        "per:founder": 3,
     }
-    assert [taskmodule.id_to_label[i] for i in range(4)] == [
-        taskmodule.none_label,
-        "org:founded_by",
-        "per:employee_of",
-        "per:founder",
-    ]
-    assert taskmodule.label_to_id[taskmodule.none_label] == 0
 
 
 def test_config(prepared_taskmodule_optional_marker):

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 import numpy
@@ -354,12 +355,12 @@ def test_decode(prepared_taskmodule, documents, model_output, inplace):
 #         ) == ["[CLS]", "[H]", "Jane", "[/H]", "lives", "in", "[T]", "Berlin", "[/T]", "[SEP]"]
 
 
-# def test_save_load(tmp_path, prepared_taskmodule):
-#     path = os.path.join(tmp_path, "taskmodule")
-#     prepared_taskmodule.save_pretrained(path)
-#     loaded_taskmodule = TransformerRETextClassificationTaskModule.from_pretrained(path)
-#     assert loaded_taskmodule.is_prepared()
-#     assert loaded_taskmodule.argument_markers == prepared_taskmodule.argument_markers
+def test_save_load(tmp_path, prepared_taskmodule):
+    path = os.path.join(tmp_path, "taskmodule")
+    prepared_taskmodule.save_pretrained(path)
+    loaded_taskmodule = TransformerRETextClassificationTaskModule.from_pretrained(path)
+    assert loaded_taskmodule.is_prepared
+    assert loaded_taskmodule.argument_markers == prepared_taskmodule.argument_markers
 
 
 # def test_enumerate_entity_pairs(prepared_taskmodule, documents):

--- a/tests/taskmodules/test_transformer_span_classification.py
+++ b/tests/taskmodules/test_transformer_span_classification.py
@@ -53,9 +53,7 @@ def model_output():
 
 def test_prepare(taskmodule, documents):
     taskmodule.prepare(documents)
-    assert set(taskmodule.label_to_id.keys()) == {"PER", "ORG", "O"}
-    assert [taskmodule.id_to_label[i] for i in range(3)] == ["O", "ORG", "PER"]
-    assert taskmodule.label_to_id["O"] == 0
+    assert taskmodule.label_to_id == {"O": 0, "ORG": 1, "PER": 2}
 
 
 def test_config(prepared_taskmodule):

--- a/tests/taskmodules/test_transformer_span_classification.py
+++ b/tests/taskmodules/test_transformer_span_classification.py
@@ -19,9 +19,14 @@ def taskmodule():
     return taskmodule
 
 
-@pytest.fixture
-def prepared_taskmodule(taskmodule, documents):
-    taskmodule.prepare(documents)
+@pytest.fixture(scope="module")
+def prepared_taskmodule(documents_to_prepare):
+    tokenizer_name_or_path = "bert-base-cased"
+    taskmodule = TransformerSpanClassificationTaskModule(
+        tokenizer_name_or_path=tokenizer_name_or_path
+    )
+
+    taskmodule.prepare(documents_to_prepare)
     return taskmodule
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -23,9 +23,9 @@ def taskmodule():
     return taskmodule
 
 
-@pytest.fixture
-def prepared_taskmodule(taskmodule, documents):
-    taskmodule.prepare(documents)
+@pytest.fixture(scope="module")
+def prepared_taskmodule(taskmodule, documents_to_prepare):
+    taskmodule.prepare(documents_to_prepare)
     return taskmodule
 
 


### PR DESCRIPTION
Approach: The base taskmodule now has also a `_prepare()` method which should be overwritten in derived classes instead of `prepare()`. Furthermore, there is a `_post_prepare()`. `prepare()` does now the following: 
1. it checks, if the property `is_prepared` is True and logs a warning with already prepared argument in this case, terminates
2. otherwise, calls `_prepare(documents)` and `_post_prepare()`

Furthermore, the taskmodule constructor now takes a parameter `require_preparation: Optional[List[str]] = None` that indicates arguments that need to be set to make the taskmodule prepared. it is best set via the `@taskmodule_init(require_preparation)` function annotator that should be added to taskmodule constructors. It sets the require_preparation and also calls `_post_prepare()` after the init was called when the taskmodule was loaded via from_pretrained. The parameter  `require_preparation` is also used to automatically add the respective values to the config.  

Finally, the following properties are implemented:
- `is_prepared`: True iff all values in `require_preparation` have a respective attribute value in self
- `prepared_arguments`: returns a dict with keys from `require_preparation` and respective attributes of self as values if these are not None