### PR TITLE
fix iter document

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -130,7 +130,7 @@ class Document(Mapping[str, Any]):
         return getattr(self, key)
 
     def __iter__(self):
-        return iter((field.name, getattr(self, field.name)) for field in self._annotation_fields)
+        return iter((field, getattr(self, field)) for field in self._annotation_fields)
 
     def __len__(self):
         return len(self._annotation_fields)

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -130,7 +130,7 @@ class Document(Mapping[str, Any]):
         return getattr(self, key)
 
     def __iter__(self):
-        return iter((field, getattr(self, field)) for field in self._annotation_fields)
+        return iter(self._annotation_fields)
 
     def __len__(self):
         return len(self._annotation_fields)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -108,6 +108,5 @@ def test_document_with_annotations():
 
     # number of annotation fields
     assert len(document1) == 3
-
-    annotation_fields = {name: field for name, field in document1}
-    assert set(annotation_fields) == {"sentences", "entities", "relations"}
+    # actual annotation fields (tests __iter__)
+    assert set(document1) == {"sentences", "entities", "relations"}

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -105,3 +105,9 @@ def test_document_with_annotations():
     assert document1["sentences"].predictions[1].target == document1.text
 
     assert document1 == TestDocument.fromdict(document1.asdict())
+
+    # number of annotation fields
+    assert len(document1) == 3
+
+    annotation_fields = {name: field for name, field in document1}
+    assert set(annotation_fields) == {"sentences", "entities", "relations"}


### PR DESCRIPTION
Iterating a document failed so far. With this PR, `Document.__iter__` will return just the names of the annotation fields (following the convention for `Mapping`s).

Note: `nox -p3.9 --session=tests_no_local_datasets` passes except one test with external cause (this is fixed in #198).