### PR TITLE
adjust test with conll2003

### DIFF
--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -184,9 +184,6 @@ def test_load_with_hf_datasets_from_hub():
 
     assert set(dataset.keys()) == {"train", "validation", "test"}
 
-    # TODO: the updated CoNLL03 data files have two newlines at the end
-    # this results in one additional example in train, validation, and test
-    # --> file a bug report in HF datasets
-    assert len(dataset["train"]) == 14042  # 14041
-    assert len(dataset["validation"]) == 3251
-    assert len(dataset["test"]) == 3454
+    assert len(dataset["train"]) == 14041
+    assert len(dataset["validation"]) == 3250
+    assert len(dataset["test"]) == 3453


### PR DESCRIPTION
The root issues was fixed (see https://huggingface.co/datasets/conll2003/commit/331adb7e97519e443e4c23e33c4805c9fd5a9381), so we can correct the expected numbers.

Note: `nox -p3.9 --session=tests_no_local_datasets` passed.