### PR TITLE
fix training seq2seq

### DIFF
--- a/src/pytorch_ie/models/transformer_seq2seq.py
+++ b/src/pytorch_ie/models/transformer_seq2seq.py
@@ -9,9 +9,7 @@ from pytorch_ie.core import PyTorchIEModel
 TransformerSeq2SeqModelBatchEncoding = BatchEncoding
 TransformerSeq2SeqModelBatchOutput = Seq2SeqLMOutput  # TODO: is this the correct type?
 
-TransformerSeq2SeqModelStepBatchEncoding = Tuple[
-    TransformerSeq2SeqModelBatchEncoding,
-]
+TransformerSeq2SeqModelStepBatchEncoding = Tuple[TransformerSeq2SeqModelBatchEncoding,]
 
 
 @PyTorchIEModel.register()

--- a/src/pytorch_ie/models/transformer_seq2seq.py
+++ b/src/pytorch_ie/models/transformer_seq2seq.py
@@ -1,16 +1,17 @@
-from typing import Any
+from typing import Any, Tuple
 
 import torch
 from transformers import AutoConfig, AutoModelForSeq2SeqLM, BatchEncoding
 from transformers.modeling_outputs import Seq2SeqLMOutput
 
 from pytorch_ie.core import PyTorchIEModel
-from pytorch_ie.core.taskmodule import Metadata
 
 TransformerSeq2SeqModelBatchEncoding = BatchEncoding
 TransformerSeq2SeqModelBatchOutput = Seq2SeqLMOutput  # TODO: is this the correct type?
 
-TransformerSeq2SeqModelStepBatchEncoding = TransformerSeq2SeqModelBatchEncoding
+TransformerSeq2SeqModelStepBatchEncoding = Tuple[
+    TransformerSeq2SeqModelBatchEncoding,
+]
 
 
 @PyTorchIEModel.register()
@@ -43,7 +44,8 @@ class TransformerSeq2SeqModel(PyTorchIEModel):
         return self.model.generate(**inputs, **kwargs)
 
     def step(self, batch: TransformerSeq2SeqModelStepBatchEncoding):
-        output = self.forward(batch)
+        inputs = batch[0]
+        output = self.forward(inputs)
 
         loss = output.loss
 

--- a/src/pytorch_ie/models/transformer_seq2seq.py
+++ b/src/pytorch_ie/models/transformer_seq2seq.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence, Tuple
+from typing import Any
 
 import torch
 from transformers import AutoConfig, AutoModelForSeq2SeqLM, BatchEncoding
@@ -6,14 +6,11 @@ from transformers.modeling_outputs import Seq2SeqLMOutput
 
 from pytorch_ie.core import PyTorchIEModel
 from pytorch_ie.core.taskmodule import Metadata
-from pytorch_ie.documents import TextDocument
 
 TransformerSeq2SeqModelBatchEncoding = BatchEncoding
 TransformerSeq2SeqModelBatchOutput = Seq2SeqLMOutput  # TODO: is this the correct type?
 
-TransformerSeq2SeqModelStepBatchEncoding = Tuple[
-    TransformerSeq2SeqModelBatchEncoding, None, Sequence[Metadata], Sequence[TextDocument]
-]
+TransformerSeq2SeqModelStepBatchEncoding = TransformerSeq2SeqModelBatchEncoding
 
 
 @PyTorchIEModel.register()
@@ -46,8 +43,7 @@ class TransformerSeq2SeqModel(PyTorchIEModel):
         return self.model.generate(**inputs, **kwargs)
 
     def step(self, batch: TransformerSeq2SeqModelStepBatchEncoding):
-        inputs = batch[0]
-        output = self.forward(inputs)
+        output = self.forward(batch)
 
         loss = output.loss
 

--- a/src/pytorch_ie/models/transformer_seq2seq.py
+++ b/src/pytorch_ie/models/transformer_seq2seq.py
@@ -7,7 +7,7 @@ from transformers.modeling_outputs import Seq2SeqLMOutput
 from pytorch_ie.core import PyTorchIEModel
 
 TransformerSeq2SeqModelBatchEncoding = BatchEncoding
-TransformerSeq2SeqModelBatchOutput = Seq2SeqLMOutput  # TODO: is this the correct type?
+TransformerSeq2SeqModelBatchOutput = Seq2SeqLMOutput
 
 TransformerSeq2SeqModelStepBatchEncoding = Tuple[TransformerSeq2SeqModelBatchEncoding,]
 
@@ -35,7 +35,6 @@ class TransformerSeq2SeqModel(PyTorchIEModel):
         inputs: Any,
         **kwargs,
     ) -> Any:
-        # TODO: check if this is necessary
         if "labels" in inputs:
             inputs = {k: v for k, v in inputs.items() if k != "labels"}
 

--- a/src/pytorch_ie/taskmodules/transformer_seq2seq.py
+++ b/src/pytorch_ie/taskmodules/transformer_seq2seq.py
@@ -213,7 +213,7 @@ class TransformerSeq2SeqTaskModule(_TransformerSeq2SeqTaskModule):
             # TODO: this is a bit of a hack -- fix
             padded_encoding["labels"] = padded_labels["input_ids"]
 
-        return padded_encoding
+        return padded_encoding,
 
     # TODO: improve this method as soon as we have unittests for this taskmodule
     def _extract_triplets(self, text) -> TransformerSeq2SeqTaskOutput:

--- a/src/pytorch_ie/taskmodules/transformer_seq2seq.py
+++ b/src/pytorch_ie/taskmodules/transformer_seq2seq.py
@@ -213,7 +213,7 @@ class TransformerSeq2SeqTaskModule(_TransformerSeq2SeqTaskModule):
             # TODO: this is a bit of a hack -- fix
             padded_encoding["labels"] = padded_labels["input_ids"]
 
-        return padded_encoding,
+        return (padded_encoding,)
 
     # TODO: improve this method as soon as we have unittests for this taskmodule
     def _extract_triplets(self, text) -> TransformerSeq2SeqTaskOutput:

--- a/src/pytorch_ie/taskmodules/transformer_seq2seq.py
+++ b/src/pytorch_ie/taskmodules/transformer_seq2seq.py
@@ -187,8 +187,6 @@ class TransformerSeq2SeqTaskModule(_TransformerSeq2SeqTaskModule):
         self, task_encodings: Sequence[TransformerSeq2SeqTaskEncoding]
     ) -> TransformerSeq2SeqModelStepBatchEncoding:
         input_features = [task_encoding.inputs for task_encoding in task_encodings]
-        metadata = [task_encoding.metadata for task_encoding in task_encodings]
-        documents = [task_encoding.document for task_encoding in task_encodings]
 
         padded_encoding = self.tokenizer.pad(
             input_features,
@@ -215,7 +213,7 @@ class TransformerSeq2SeqTaskModule(_TransformerSeq2SeqTaskModule):
             # TODO: this is a bit of a hack -- fix
             padded_encoding["labels"] = padded_labels["input_ids"]
 
-        return padded_encoding, None, metadata, documents
+        return padded_encoding
 
     # TODO: improve this method as soon as we have unittests for this taskmodule
     def _extract_triplets(self, text) -> TransformerSeq2SeqTaskOutput:

--- a/tests/models/test_transformer_seq2seq.py
+++ b/tests/models/test_transformer_seq2seq.py
@@ -1,0 +1,198 @@
+import pytest
+import torch
+import transformers
+from transformers import BatchEncoding
+from transformers.modeling_outputs import Seq2SeqLMOutput
+
+from pytorch_ie import TransformerSeq2SeqModel
+
+LOSS = torch.rand(1).to(dtype=torch.float)
+# a batch with one entry: 10 tokens from a 100-token vocabulary
+TOKEN_IDS = torch.randint(0, 100, (1, 10))
+
+
+class MockModel:
+    def __init__(self) -> None:
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return Seq2SeqLMOutput(loss=LOSS)
+
+    def generate(self, **kwargs):
+        return TOKEN_IDS
+
+
+@pytest.fixture
+def mock_model(monkeypatch):
+    monkeypatch.setattr(
+        transformers.AutoModelForSeq2SeqLM,
+        "from_config",
+        lambda config: MockModel(),
+    )
+    monkeypatch.setattr(
+        transformers.AutoModelForSeq2SeqLM,
+        "from_pretrained",
+        lambda pretrained_model_name_or_path: MockModel(),
+    )
+
+    model = TransformerSeq2SeqModel(model_name_or_path="some-model-name")
+    assert not model.is_from_pretrained
+
+    return model
+
+
+@pytest.fixture(scope="module")
+def batch():
+    # taken from tests.taskmodules.test_transformer_seq2seq.test_collate()
+    input_ids = torch.IntTensor(
+        [
+            [
+                0,
+                17,
+                48,
+                31845,
+                10,
+                2422,
+                22307,
+                11838,
+                12,
+                611,
+                13552,
+                5897,
+                16,
+                129,
+                457,
+                9,
+                24,
+                6,
+                17,
+                46,
+                26,
+                6002,
+                2265,
+                26942,
+                6,
+                937,
+                1784,
+                23,
+                36363,
+                846,
+                8,
+                4196,
+                736,
+                9,
+                35890,
+                40790,
+                4,
+                2,
+            ],
+        ]
+    ).to(dtype=torch.int64)
+    attention_mask = torch.IntTensor(
+        [
+            [
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+            ],
+        ]
+    ).to(dtype=torch.int64)
+    labels = torch.IntTensor(
+        [
+            [
+                0,
+                50267,
+                11838,
+                12,
+                611,
+                13552,
+                5897,
+                1437,
+                50266,
+                2422,
+                1437,
+                50265,
+                34,
+                1215,
+                90,
+                14631,
+                2,
+            ],
+        ]
+    ).to(dtype=torch.int64)
+
+    encoding = BatchEncoding(
+        data={
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "labels": labels,
+        }
+    )
+    # IMPORTANT: We return a tuple (note the comma)!
+    return (encoding,)
+
+
+def test_forward(mock_model, batch):
+    (inputs,) = batch
+    output = mock_model.forward(inputs)
+
+    assert isinstance(output, Seq2SeqLMOutput)
+    loss = output.loss
+    torch.testing.assert_close(loss, LOSS)
+
+
+def test_predict(mock_model, batch):
+    # taken from src.pipeline.Pipeline._forward
+    inputs = batch[0]
+    prediction = mock_model.predict(inputs=inputs.data)
+    torch.testing.assert_close(prediction, TOKEN_IDS)
+
+
+def test_training_step(mock_model, batch):
+    loss = mock_model.training_step(batch, batch_idx=0)
+    torch.testing.assert_close(loss, LOSS)
+
+
+def test_validation_step(mock_model, batch):
+    loss = mock_model.validation_step(batch, batch_idx=0)
+    torch.testing.assert_close(loss, LOSS)
+
+
+def test_test_step(mock_model, batch):
+    loss = mock_model.test_step(batch, batch_idx=0)
+    torch.testing.assert_close(loss, LOSS)

--- a/tests/taskmodules/test_transformer_seq2seq.py
+++ b/tests/taskmodules/test_transformer_seq2seq.py
@@ -1,0 +1,476 @@
+from copy import copy
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from pytorch_ie import TransformerSeq2SeqTaskModule
+from pytorch_ie.annotations import BinaryRelation, LabeledSpan
+from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.documents import TextDocument
+
+
+@pytest.fixture(scope="module")
+def taskmodule():
+    transformer_model = "Babelscape/rebel-large"
+    taskmodule = TransformerSeq2SeqTaskModule(tokenizer_name_or_path=transformer_model)
+    assert not taskmodule.is_from_pretrained
+
+    return taskmodule
+
+
+def test_taskmodule(taskmodule):
+    assert taskmodule is not None
+
+
+@dataclass
+class ExampleDocument(TextDocument):
+    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+
+@pytest.fixture(scope="module")
+def document():
+    result = ExampleDocument(
+        "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV "
+        "and managing director of IndieBio."
+    )
+    # add a made-up relation
+    head = LabeledSpan(start=22, end=38, label="food")
+    tail = LabeledSpan(start=10, end=15, label="taste")
+    rel = BinaryRelation(head=head, tail=tail, label="has_taste")
+    result.entities.append(head)
+    result.entities.append(tail)
+    result.relations.append(rel)
+    return result
+
+
+@pytest.fixture(scope="module")
+def task_encoding_without_targets(taskmodule, document):
+    result = taskmodule.encode_input(document)
+    return result
+
+
+def test_encode_input(task_encoding_without_targets, document, taskmodule):
+    assert task_encoding_without_targets is not None
+    assert task_encoding_without_targets.document == document
+    assert not task_encoding_without_targets.has_targets
+    expected_input_tokens = [
+        "<s>",
+        "âĢ",
+        "ľ",
+        "Making",
+        "Ġa",
+        "Ġsuper",
+        "Ġtasty",
+        "Ġalt",
+        "-",
+        "ch",
+        "icken",
+        "Ġwing",
+        "Ġis",
+        "Ġonly",
+        "Ġhalf",
+        "Ġof",
+        "Ġit",
+        ",",
+        "âĢ",
+        "Ŀ",
+        "Ġsaid",
+        "ĠPo",
+        "ĠBr",
+        "onson",
+        ",",
+        "Ġgeneral",
+        "Ġpartner",
+        "Ġat",
+        "ĠSOS",
+        "V",
+        "Ġand",
+        "Ġmanaging",
+        "Ġdirector",
+        "Ġof",
+        "ĠIndie",
+        "Bio",
+        ".",
+        "</s>",
+    ]
+    assert set(task_encoding_without_targets.inputs) == {"input_ids", "attention_mask"}
+    input_tokens = taskmodule.tokenizer.convert_ids_to_tokens(
+        task_encoding_without_targets.inputs["input_ids"]
+    )
+    assert input_tokens == expected_input_tokens
+    assert task_encoding_without_targets.inputs["attention_mask"] == [1] * len(
+        expected_input_tokens
+    )
+    assert task_encoding_without_targets.metadata == {}
+
+
+@pytest.fixture(scope="module")
+def target(taskmodule, task_encoding_without_targets):
+    return taskmodule.encode_target(task_encoding_without_targets)
+
+
+def test_target(target, taskmodule):
+    expected_label_tokens = [
+        "<s>",
+        "<triplet>",
+        "Ġalt",
+        "-",
+        "ch",
+        "icken",
+        "Ġwing",
+        "Ġ",
+        "<subj>",
+        "Ġsuper",
+        "Ġ",
+        "<obj>",
+        "Ġhas",
+        "_",
+        "t",
+        "aste",
+        "</s>",
+    ]
+    assert set(target) == {"labels"}
+    label_tokens = taskmodule.tokenizer.convert_ids_to_tokens(target["labels"])
+    assert label_tokens == expected_label_tokens
+
+
+@pytest.fixture(scope="module")
+def task_encoding(task_encoding_without_targets, target):
+    result = copy(task_encoding_without_targets)
+    result.targets = target
+    return result
+
+
+@pytest.fixture(scope="module")
+def model_predict_output():
+    return torch.IntTensor(
+        [
+            [
+                0,
+                50267,
+                36363,
+                846,
+                1437,
+                50266,
+                35890,
+                40790,
+                1437,
+                50265,
+                8540,
+                1437,
+                50267,
+                35890,
+                40790,
+                1437,
+                50266,
+                36363,
+                846,
+                1437,
+                50265,
+                4095,
+                1651,
+                2,
+            ]
+        ],
+    )
+
+
+@pytest.fixture(scope="module")
+def unbatched_outputs(taskmodule, model_predict_output):
+    result = taskmodule.unbatch_output(model_predict_output)
+    return result
+
+
+def test_unpatch_output(unbatched_outputs):
+    assert unbatched_outputs == [
+        [
+            {"head": "SOSV", "type": "subsidiary", "tail": "IndieBio"},
+            {"head": "IndieBio", "type": "parent organization", "tail": "SOSV"},
+        ]
+    ]
+
+
+@pytest.fixture(scope="module")
+def annotations_from_output(taskmodule, task_encoding_without_targets, unbatched_outputs):
+    task_encodings = [task_encoding_without_targets]
+    assert len(task_encodings) == len(unbatched_outputs)
+    named_annotations = []
+    for task_encoding, unbatched_output in zip(task_encodings, unbatched_outputs):
+        named_annotations.extend(
+            taskmodule.create_annotations_from_output(
+                task_encoding=task_encoding, task_output=unbatched_output
+            )
+        )
+    return named_annotations
+
+
+def test_annotations_from_output(annotations_from_output):
+    assert annotations_from_output is not None
+    assert len(annotations_from_output) == 6
+    assert annotations_from_output[0] == (
+        "entities",
+        LabeledSpan(start=96, end=100, label="head", score=1.0),
+    )
+    assert annotations_from_output[1] == (
+        "entities",
+        LabeledSpan(start=126, end=134, label="tail", score=1.0),
+    )
+    assert annotations_from_output[2] == (
+        "relations",
+        BinaryRelation(
+            head=LabeledSpan(start=96, end=100, label="head", score=1.0),
+            tail=LabeledSpan(start=126, end=134, label="tail", score=1.0),
+            label="subsidiary",
+            score=1.0,
+        ),
+    )
+    assert annotations_from_output[3] == (
+        "entities",
+        LabeledSpan(start=126, end=134, label="head", score=1.0),
+    )
+    assert annotations_from_output[4] == (
+        "entities",
+        LabeledSpan(start=96, end=100, label="tail", score=1.0),
+    )
+    assert annotations_from_output[5] == (
+        "relations",
+        BinaryRelation(
+            head=LabeledSpan(start=126, end=134, label="head", score=1.0),
+            tail=LabeledSpan(start=96, end=100, label="tail", score=1.0),
+            label="parent organization",
+            score=1.0,
+        ),
+    )
+
+
+@pytest.fixture(scope="module")
+def batch(taskmodule, task_encoding):
+    return taskmodule.collate(task_encodings=[task_encoding, task_encoding])
+
+
+def test_collate(batch):
+    assert batch is not None
+    # each batch consists of just one entry (this is not the number of batches!)
+    assert len(batch) == 1
+    assert set(batch[0].data) == {"input_ids", "attention_mask", "labels"}
+
+    input_ids = batch[0].input_ids
+    input_ids_expected = torch.IntTensor(
+        [
+            [
+                0,
+                17,
+                48,
+                31845,
+                10,
+                2422,
+                22307,
+                11838,
+                12,
+                611,
+                13552,
+                5897,
+                16,
+                129,
+                457,
+                9,
+                24,
+                6,
+                17,
+                46,
+                26,
+                6002,
+                2265,
+                26942,
+                6,
+                937,
+                1784,
+                23,
+                36363,
+                846,
+                8,
+                4196,
+                736,
+                9,
+                35890,
+                40790,
+                4,
+                2,
+            ],
+            [
+                0,
+                17,
+                48,
+                31845,
+                10,
+                2422,
+                22307,
+                11838,
+                12,
+                611,
+                13552,
+                5897,
+                16,
+                129,
+                457,
+                9,
+                24,
+                6,
+                17,
+                46,
+                26,
+                6002,
+                2265,
+                26942,
+                6,
+                937,
+                1784,
+                23,
+                36363,
+                846,
+                8,
+                4196,
+                736,
+                9,
+                35890,
+                40790,
+                4,
+                2,
+            ],
+        ]
+    ).to(dtype=torch.int64)
+    torch.testing.assert_close(input_ids, input_ids_expected)
+
+    attention_mask = batch[0].attention_mask
+    attention_mask_expected = torch.IntTensor(
+        [
+            [
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+            ],
+            [
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+            ],
+        ]
+    ).to(dtype=torch.int64)
+    torch.testing.assert_close(attention_mask, attention_mask_expected)
+
+    labels = batch[0].labels
+    labels_expected = torch.IntTensor(
+        [
+            [
+                0,
+                50267,
+                11838,
+                12,
+                611,
+                13552,
+                5897,
+                1437,
+                50266,
+                2422,
+                1437,
+                50265,
+                34,
+                1215,
+                90,
+                14631,
+                2,
+            ],
+            [
+                0,
+                50267,
+                11838,
+                12,
+                611,
+                13552,
+                5897,
+                1437,
+                50266,
+                2422,
+                1437,
+                50265,
+                34,
+                1215,
+                90,
+                14631,
+                2,
+            ],
+        ]
+    ).to(dtype=torch.int64)
+    torch.testing.assert_close(labels, labels_expected)

--- a/tests/taskmodules/test_transformer_seq2seq.py
+++ b/tests/taskmodules/test_transformer_seq2seq.py
@@ -247,7 +247,7 @@ def test_annotations_from_output(annotations_from_output):
 
 @pytest.fixture(scope="module")
 def batch(taskmodule, task_encoding):
-    return taskmodule.collate(task_encodings=[task_encoding, task_encoding])
+    return taskmodule.collate(task_encodings=[task_encoding])
 
 
 def test_collate(batch):
@@ -259,46 +259,6 @@ def test_collate(batch):
     input_ids = batch[0].input_ids
     input_ids_expected = torch.IntTensor(
         [
-            [
-                0,
-                17,
-                48,
-                31845,
-                10,
-                2422,
-                22307,
-                11838,
-                12,
-                611,
-                13552,
-                5897,
-                16,
-                129,
-                457,
-                9,
-                24,
-                6,
-                17,
-                46,
-                26,
-                6002,
-                2265,
-                26942,
-                6,
-                937,
-                1784,
-                23,
-                36363,
-                846,
-                8,
-                4196,
-                736,
-                9,
-                35890,
-                40790,
-                4,
-                2,
-            ],
             [
                 0,
                 17,
@@ -386,46 +346,6 @@ def test_collate(batch):
                 1,
                 1,
             ],
-            [
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-                1,
-            ],
         ]
     ).to(dtype=torch.int64)
     torch.testing.assert_close(attention_mask, attention_mask_expected)
@@ -433,25 +353,6 @@ def test_collate(batch):
     labels = batch[0].labels
     labels_expected = torch.IntTensor(
         [
-            [
-                0,
-                50267,
-                11838,
-                12,
-                611,
-                13552,
-                5897,
-                1437,
-                50266,
-                2422,
-                1437,
-                50265,
-                34,
-                1215,
-                90,
-                14631,
-                2,
-            ],
             [
                 0,
                 50267,


### PR DESCRIPTION
This was broken because pytorch-lightning tries to move the output of `TransformerSeq2SeqTaskModule.collate` to a device via `pytorch_lightning.core.datamodule.LightningDataModule.transfer_batch_to_device` that internally uses [`pytorch_lightning.utilities.apply_func.apply_to_collection`](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.utilities.apply_func.html#pytorch_lightning.utilities.apply_func.apply_to_collection). This method fails if any part of the input (arbitrary nested) is a frozen `dataclass` which is the case for our `Annotation`s. To fix this, we simply remove the documents (and also metadata) from the batch since it is not used at all.

Note that this PR also adds tests for the seq2seq taskmodule and the seq2seq model. `nox -p3.9 --session=tests_no_local_datasets` passes successfully (tested locally).