### PR TITLE
Improve readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This is an experimental framework that aims to combine the lessons learned from 
 $ pip install pytorch-ie
 ```
 
-## ⚡️ Example
+## ⚡️ Examples
 
 **Note:** Setting `num_workers=0` in the pipeline is only necessary when running an example in an
 interactive python session. The reason is that multiprocessing doesn't play well with the interactive python
@@ -109,9 +109,14 @@ ner_pipeline = Pipeline(model=ner_model, taskmodule=ner_taskmodule, device=-1, n
 ```
 </details>
 
-## ⚡️️️️ More Examples
+<br>
+
+<details>
+<summary>
 
 ### Text-classification-based Relation Extraction
+
+</summary>
 
 ```python
 from dataclasses import dataclass
@@ -147,7 +152,7 @@ for relation in document.relations.predictions:
 # (SOSV -> Po Bronson) -> org:top_members/employees
 # (IndieBio -> Po Bronson) -> org:top_members/employees
 ```
-
+</details>
 
 ## 🔭 Demos
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ for entity in document.entities.predictions:
 # SOSV -> ORG
 ```
 
-To create the same pipeline as above without `AutoPipeline`:
+<details>
+<summary>
+To create the same pipeline as above without `AutoPipeline`
+</summary>
 
 ```python
 from pytorch_ie.auto import AutoTaskModule, AutoModel
@@ -87,8 +90,12 @@ ner_taskmodule = AutoTaskModule.from_pretrained(model_name_or_path)
 ner_model = AutoModel.from_pretrained(model_name_or_path)
 ner_pipeline = Pipeline(model=ner_model, taskmodule=ner_taskmodule, device=-1, num_workers=0)
 ```
+</details>
 
-Or, without `Auto` classes at all:
+<details>
+<summary>
+Or, without `Auto` classes at all
+</summary>
 
 ```python
 from pytorch_ie.pipeline import Pipeline
@@ -100,6 +107,7 @@ ner_taskmodule = TransformerSpanClassificationTaskModule.from_pretrained(model_n
 ner_model = TransformerSpanClassificationModel.from_pretrained(model_name_or_path)
 ner_pipeline = Pipeline(model=ner_model, taskmodule=ner_taskmodule, device=-1, num_workers=0)
 ```
+</details>
 
 ## ⚡️️️️ More Examples
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ pip install pytorch-ie
 
 ## ⚡️ Examples: Prediction
 
-The following examples work out of the box. No further setup like manually downloading a model is needed!
+**The following examples work out of the box. No further setup like manually downloading a model is needed!**
 
 **Note:** Setting `num_workers=0` in the pipeline is only necessary when running an example in an
 interactive python session. The reason is that multiprocessing doesn't play well with the interactive python

--- a/README.md
+++ b/README.md
@@ -157,7 +157,91 @@ for relation in document.relations.predictions:
 
 ## ⚡️ Examples: Training
 
-TODO
+### Span-classification-based Named Entity Recognition
+
+```python
+import pytorch_lightning as pl
+from pytorch_lightning.callbacks import ModelCheckpoint
+from torch.utils.data import DataLoader
+
+import datasets
+from pytorch_ie.models.transformer_span_classification import TransformerSpanClassificationModel
+from pytorch_ie.taskmodules.transformer_span_classification import (
+    TransformerSpanClassificationTaskModule,
+)
+
+pl.seed_everything(42)
+
+model_output_path = "./model_output/"
+model_name = "bert-base-cased"
+num_epochs = 10
+batch_size = 32
+
+dataset = datasets.load_dataset(
+    path="pie/conll2003",
+)
+train_docs, val_docs = dataset["train"], dataset["validation"]
+
+print("train docs: ", len(train_docs))
+print("val docs: ", len(val_docs))
+
+task_module = TransformerSpanClassificationTaskModule(
+    tokenizer_name_or_path=model_name,
+    max_length=128,
+)
+
+task_module.prepare(train_docs)
+
+train_dataset = task_module.encode(train_docs, encode_target=True)
+val_dataset = task_module.encode(val_docs, encode_target=True)
+
+train_dataloader = DataLoader(
+    train_dataset,
+    batch_size=batch_size,
+    shuffle=True,
+    collate_fn=task_module.collate,
+)
+
+val_dataloader = DataLoader(
+    val_dataset,
+    batch_size=batch_size,
+    shuffle=False,
+    collate_fn=task_module.collate,
+)
+
+model = TransformerSpanClassificationModel(
+    model_name_or_path=model_name,
+    num_classes=len(task_module.label_to_id),
+    t_total=len(train_dataloader) * num_epochs,
+    learning_rate=1e-4,
+)
+
+# checkpoint_callback = ModelCheckpoint(
+#     monitor="val/f1",
+#     dirpath=model_output_path,
+#     filename="zs-ner-{epoch:02d}-val_f1-{val/f1:.2f}",
+#     save_top_k=1,
+#     mode="max",
+#     auto_insert_metric_name=False,
+#     save_weights_only=True,
+# )
+
+trainer = pl.Trainer(
+    fast_dev_run=False,
+    max_epochs=num_epochs,
+    gpus=0,
+    checkpoint_callback=False,
+    # callbacks=[checkpoint_callback],
+    precision=32,
+)
+trainer.fit(model, train_dataloader, val_dataloader)
+
+# task_module.save_pretrained(model_output_path)
+
+# trainer.save_checkpoint(model_output_path + "model.ckpt")
+# or
+# model.save_pretrained(model_output_path)
+```
 
 ## 🔭 Demos
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ for relation in document.relations.predictions:
 
 TODO
 
-
 ## 🔭 Demos
 
 | Task                                                       | Link                                                                                                                                                                  |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This is an experimental framework that aims to combine the lessons learned from 
 $ pip install pytorch-ie
 ```
 
-## ⚡️ Examples
+## ⚡️ Examples: Inference
 
 **Note:** Setting `num_workers=0` in the pipeline is only necessary when running an example in an
 interactive python session. The reason is that multiprocessing doesn't play well with the interactive python
@@ -154,6 +154,11 @@ for relation in document.relations.predictions:
 ```
 
 </details>
+
+## ⚡️ Examples: Training
+
+TODO
+
 
 ## 🔭 Demos
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ ner_taskmodule = AutoTaskModule.from_pretrained(model_name_or_path)
 ner_model = AutoModel.from_pretrained(model_name_or_path)
 ner_pipeline = Pipeline(model=ner_model, taskmodule=ner_taskmodule, device=-1, num_workers=0)
 ```
+
 </details>
 
 <details>
@@ -107,9 +108,8 @@ ner_taskmodule = TransformerSpanClassificationTaskModule.from_pretrained(model_n
 ner_model = TransformerSpanClassificationModel.from_pretrained(model_name_or_path)
 ner_pipeline = Pipeline(model=ner_model, taskmodule=ner_taskmodule, device=-1, num_workers=0)
 ```
-</details>
 
-<br>
+</details>
 
 <details>
 <summary>
@@ -152,6 +152,7 @@ for relation in document.relations.predictions:
 # (SOSV -> Po Bronson) -> org:top_members/employees
 # (IndieBio -> Po Bronson) -> org:top_members/employees
 ```
+
 </details>
 
 ## 🔭 Demos

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $ pip install pytorch-ie
 
 ## ⚡️ Examples: Prediction
 
+The following examples work out of the box. No further setup like manually downloading a model is needed! 
+
 **Note:** Setting `num_workers=0` in the pipeline is only necessary when running an example in an
 interactive python session. The reason is that multiprocessing doesn't play well with the interactive python
 interpreter, see [here](https://docs.python.org/3/library/multiprocessing.html#using-a-pool-of-workers)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ pip install pytorch-ie
 
 ## ⚡️ Examples: Prediction
 
-The following examples work out of the box. No further setup like manually downloading a model is needed! 
+The following examples work out of the box. No further setup like manually downloading a model is needed!
 
 **Note:** Setting `num_workers=0` in the pipeline is only necessary when running an example in an
 interactive python session. The reason is that multiprocessing doesn't play well with the interactive python

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This is an experimental framework that aims to combine the lessons learned from 
 $ pip install pytorch-ie
 ```
 
-## ⚡️ Examples: Inference
+## ⚡️ Examples: Prediction
 
 **Note:** Setting `num_workers=0` in the pipeline is only necessary when running an example in an
 interactive python session. The reason is that multiprocessing doesn't play well with the interactive python

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ This is an experimental framework that aims to combine the lessons learned from 
 -   **Character-level annotation and evaluation:** Many information extraction frameworks annotate and evaluate on a token level. We believe that annotation and evaluation should be done on a character level as this also considers the suitability of the tokenizer for the task.
 -   **Make no assumptions on the structure of models:** The last years have seen many different and creative approaches to information extraction and a framework that imposes a structure on those will most certainly be to limiting. With PyTorch-iE you have full control over how a document is prepared for a model and how the model is structured. The logic is self-contained and thus can be easily shared and inspected by others. The only assumption we make is that the input is a document and the output are targets (training) or annotations (inference).
 
+## 🔭 Demos
+
+| Task                                                       | Link                                                                                                                                                                  |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Named Entity Recognition (Span-based)                      | [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/pie/NER)                               |
+| Joint Named Entity Recognition and Relation Classification | [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/pie/Joint-NER-and-Relation-Extraction) |
+
 ## 🚀️ Quickstart
 
 ```console
@@ -270,13 +277,6 @@ trainer.fit(model, train_dataloader, val_dataloader)
 ```
 
 </details>
-
-## 🔭 Demos
-
-| Task                                                       | Link                                                                                                                                                                  |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Named Entity Recognition (Span-based)                      | [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/pie/NER)                               |
-| Joint Named Entity Recognition and Relation Classification | [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/pie/Joint-NER-and-Relation-Extraction) |
 
 ## 📚 Datasets
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,110 @@ This is an experimental framework that aims to combine the lessons learned from 
 $ pip install pytorch-ie
 ```
 
+## ⚡️ Example
+
+**Note:** Setting `num_workers=0` in the pipeline is only necessary when running an example in an
+interactive python session. The reason is that multiprocessing doesn't play well with the interactive python
+interpreter, see [here](https://docs.python.org/3/library/multiprocessing.html#using-a-pool-of-workers)
+for details.
+
+### Span-classification-based Named Entity Recognition
+
+```python
+from dataclasses import dataclass
+
+from pytorch_ie.annotations import LabeledSpan
+from pytorch_ie.auto import AutoPipeline
+from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.documents import TextDocument
+
+@dataclass
+class ExampleDocument(TextDocument):
+    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+
+document = ExampleDocument(
+    "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
+)
+
+# see below for the long version
+ner_pipeline = AutoPipeline.from_pretrained("pie/example-ner-spanclf-conll03", device=-1, num_workers=0)
+
+ner_pipeline(document, predict_field="entities")
+
+for entity in document.entities.predictions:
+    print(f"{entity} -> {entity.label}")
+
+# Result:
+# IndieBio -> ORG
+# Po Bronson -> PER
+# SOSV -> ORG
+```
+
+To create the same pipeline as above without `AutoPipeline`:
+
+```python
+from pytorch_ie.auto import AutoTaskModule, AutoModel
+from pytorch_ie.pipeline import Pipeline
+
+model_name_or_path = "pie/example-ner-spanclf-conll03"
+ner_taskmodule = AutoTaskModule.from_pretrained(model_name_or_path)
+ner_model = AutoModel.from_pretrained(model_name_or_path)
+ner_pipeline = Pipeline(model=ner_model, taskmodule=ner_taskmodule, device=-1, num_workers=0)
+```
+
+Or, without `Auto` classes at all:
+
+```python
+from pytorch_ie.pipeline import Pipeline
+from pytorch_ie.models import TransformerSpanClassificationModel
+from pytorch_ie.taskmodules import TransformerSpanClassificationTaskModule
+
+model_name_or_path = "pie/example-ner-spanclf-conll03"
+ner_taskmodule = TransformerSpanClassificationTaskModule.from_pretrained(model_name_or_path)
+ner_model = TransformerSpanClassificationModel.from_pretrained(model_name_or_path)
+ner_pipeline = Pipeline(model=ner_model, taskmodule=ner_taskmodule, device=-1, num_workers=0)
+```
+
+## ⚡️️️️ More Examples
+
+### Text-classification-based Relation Extraction
+
+```python
+from dataclasses import dataclass
+
+from pytorch_ie.annotations import BinaryRelation, LabeledSpan
+from pytorch_ie.auto import AutoPipeline
+from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.documents import TextDocument
+
+
+@dataclass
+class ExampleDocument(TextDocument):
+    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+document = ExampleDocument(
+    "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
+)
+
+re_pipeline = AutoPipeline.from_pretrained("pie/example-re-textclf-tacred", device=-1, num_workers=0)
+
+for start, end, label in [(65, 75, "PER"), (96, 100, "ORG"), (126, 134, "ORG")]:
+    document.entities.append(LabeledSpan(start=start, end=end, label=label))
+
+re_pipeline(document, predict_field="relations", batch_size=2)
+
+for relation in document.relations.predictions:
+    print(f"({relation.head} -> {relation.tail}) -> {relation.label}")
+
+# Result:
+# (Po Bronson -> SOSV) -> per:employee_of
+# (Po Bronson -> IndieBio) -> per:employee_of
+# (SOSV -> Po Bronson) -> org:top_members/employees
+# (IndieBio -> Po Bronson) -> org:top_members/employees
+```
+
+
 ## 🔭 Demos
 
 | Task                                                       | Link                                                                                                                                                                  |
@@ -149,109 +253,6 @@ load the dataset with `datasets.load_dataset`, the script has to be located in a
 is the case for standard Huggingface dataset loading scripts).
 
 </details>
-
-## ⚡️ Example
-
-**Note:** Setting `num_workers=0` in the pipeline is only necessary when running an example in an
-interactive python session. The reason is that multiprocessing doesn't play well with the interactive python
-interpreter, see [here](https://docs.python.org/3/library/multiprocessing.html#using-a-pool-of-workers)
-for details.
-
-### Span-classification-based Named Entity Recognition
-
-```python
-from dataclasses import dataclass
-
-from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.auto import AutoPipeline
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextDocument
-
-@dataclass
-class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-
-document = ExampleDocument(
-    "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
-)
-
-# see below for the long version
-ner_pipeline = AutoPipeline.from_pretrained("pie/example-ner-spanclf-conll03", device=-1, num_workers=0)
-
-ner_pipeline(document, predict_field="entities")
-
-for entity in document.entities.predictions:
-    print(f"{entity} -> {entity.label}")
-
-# Result:
-# IndieBio -> ORG
-# Po Bronson -> PER
-# SOSV -> ORG
-```
-
-To create the same pipeline as above without `AutoPipeline`:
-
-```python
-from pytorch_ie.auto import AutoTaskModule, AutoModel
-from pytorch_ie.pipeline import Pipeline
-
-model_name_or_path = "pie/example-ner-spanclf-conll03"
-ner_taskmodule = AutoTaskModule.from_pretrained(model_name_or_path)
-ner_model = AutoModel.from_pretrained(model_name_or_path)
-ner_pipeline = Pipeline(model=ner_model, taskmodule=ner_taskmodule, device=-1, num_workers=0)
-```
-
-Or, without `Auto` classes at all:
-
-```python
-from pytorch_ie.pipeline import Pipeline
-from pytorch_ie.models import TransformerSpanClassificationModel
-from pytorch_ie.taskmodules import TransformerSpanClassificationTaskModule
-
-model_name_or_path = "pie/example-ner-spanclf-conll03"
-ner_taskmodule = TransformerSpanClassificationTaskModule.from_pretrained(model_name_or_path)
-ner_model = TransformerSpanClassificationModel.from_pretrained(model_name_or_path)
-ner_pipeline = Pipeline(model=ner_model, taskmodule=ner_taskmodule, device=-1, num_workers=0)
-```
-
-## ⚡️️️️ More Examples
-
-### Text-classification-based Relation Extraction
-
-```python
-from dataclasses import dataclass
-
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.auto import AutoPipeline
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextDocument
-
-
-@dataclass
-class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
-
-document = ExampleDocument(
-    "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
-)
-
-re_pipeline = AutoPipeline.from_pretrained("pie/example-re-textclf-tacred", device=-1, num_workers=0)
-
-for start, end, label in [(65, 75, "PER"), (96, 100, "ORG"), (126, 134, "ORG")]:
-    document.entities.append(LabeledSpan(start=start, end=end, label=label))
-
-re_pipeline(document, predict_field="relations", batch_size=2)
-
-for relation in document.relations.predictions:
-    print(f"({relation.head} -> {relation.tail}) -> {relation.label}")
-
-# Result:
-# (Po Bronson -> SOSV) -> per:employee_of
-# (Po Bronson -> IndieBio) -> per:employee_of
-# (SOSV -> Po Bronson) -> org:top_members/employees
-# (IndieBio -> Po Bronson) -> org:top_members/employees
-```
 
 <!-- github-only -->
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,13 @@ for relation in document.relations.predictions:
 
 ## ⚡️ Examples: Training
 
+<details>
+
+<summary>
+
 ### Span-classification-based Named Entity Recognition
+
+</summary>
 
 ```python
 import pytorch_lightning as pl
@@ -244,6 +250,8 @@ trainer.fit(model, train_dataloader, val_dataloader)
 # or
 # model.save_pretrained(model_output_path)
 ```
+
+</details>
 
 ## 🔭 Demos
 


### PR DESCRIPTION
[preview](https://github.com/ChristophAlt/pytorch-ie/tree/improve_readme_examples#pytorch-ie-state-of-the-art-information-extraction-in-pytorch)

Changes:
 * move `Examples` in front of `Datasets`
 * move `Demos` in front of `Quickstart`
 * rename `Examples` to `Examples: Prediction` (and add remark that prediction is "zero-setup")
 * collapse `To create the same pipeline as above without AutoPipeline:` and `Or, without Auto classes at all:` from `Examples: Prediction` 
 * collapse `Text-classification-based Relation Extraction` from `More Examples` and move into `Examples: Prediction`
 * add section `Examples: Training` with content from `examples/train/span_classification.py` (+ comments)