### PR TITLE
test_load_with_hf_datasets_from_hub fails

### DIFF
--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -158,7 +158,6 @@ def test_dataset_with_taskmodule(dataset, taskmodule, model_output, encode_targe
         assert not document["entities"].predictions
 
 
-@pytest.mark.slow
 def test_load_with_hf_datasets():
     dataset_path = "./datasets/conll2003"
 
@@ -176,7 +175,6 @@ def test_load_with_hf_datasets():
     assert len(dataset["test"]) == 3454
 
 
-@pytest.mark.slow
 def test_load_with_hf_datasets_from_hub():
     dataset = datasets.load_dataset(
         path="pie/conll2003",


### PR DESCRIPTION
For now, this PR just removes the slow marker for `test_load_with_hf_datasets` and `test_load_with_hf_datasets_from_hub` to test at github CI.

result:
FAILED tests/data/test_dataset.py::test_load_with_hf_datasets_from_hub