### PR TITLE
Remove _root_annotation

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -5,9 +5,15 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Uni
 
 
 def _enumerate_dependencies(
-    resolved: List[str], dependency_graph: Dict[str, List[str]], nodes: List[str]
+    resolved: List[str],
+    dependency_graph: Dict[str, List[str]],
+    nodes: List[str],
+    current_branch: Optional[Set[str]] = None,
 ):
+    current_branch = current_branch or set()
     for node in nodes:
+        if node in current_branch:
+            raise ValueError(f"circular dependency detected at node: {node}")
         if node not in resolved:
             # terminal nodes
             if node not in dependency_graph:
@@ -15,7 +21,12 @@ def _enumerate_dependencies(
             # nodes with dependencies
             else:
                 # enumerate all dependencies first, then append itself
-                _enumerate_dependencies(resolved, dependency_graph, nodes=dependency_graph[node])
+                _enumerate_dependencies(
+                    resolved,
+                    dependency_graph,
+                    nodes=dependency_graph[node],
+                    current_branch=current_branch | {node},
+                )
                 resolved.append(node)
 
 

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -8,11 +8,11 @@ def _enumerate_dependencies(
     resolved: List[str],
     dependency_graph: Dict[str, List[str]],
     nodes: List[str],
-    current_branch: Optional[Set[str]] = None,
+    current_path: Optional[Set[str]] = None,
 ):
-    current_branch = current_branch or set()
+    current_path = current_path or set()
     for node in nodes:
-        if node in current_branch:
+        if node in current_path:
             raise ValueError(f"circular dependency detected at node: {node}")
         if node not in resolved:
             # terminal nodes
@@ -25,7 +25,7 @@ def _enumerate_dependencies(
                     resolved,
                     dependency_graph,
                     nodes=dependency_graph[node],
-                    current_branch=current_branch | {node},
+                    current_path=current_path | {node},
                 )
                 resolved.append(node)
 

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -206,6 +206,10 @@ class Document(Mapping[str, Any]):
         dependency_ordered_fields: List[dataclasses.Field] = []
 
         rooted_annotation_graph = dict(doc._annotation_graph)
+        if "_dummy_root" in rooted_annotation_graph:
+            raise ValueError(
+                "the annotation graph already contains a node _dummy_root, this is not allowed"
+            )
         rooted_annotation_graph["_dummy_root"] = root_target_fields
 
         _depth_first_search(

--- a/src/pytorch_ie/documents.py
+++ b/src/pytorch_ie/documents.py
@@ -9,4 +9,3 @@ class TextDocument(Document):
     text: str
     id: Optional[str] = None
     metadata: Dict[str, Any] = dataclasses.field(default_factory=dict)
-    _root_annotation: str = dataclasses.field(default="text", init=False, repr=False)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -180,3 +180,13 @@ def test_enumerate_dependencies():
         targets = graph.get(node, [])
         for t in targets:
             assert t in already_resolved
+
+
+def test_enumerate_dependencies_with_circle():
+    graph = {"a": ["b"], "b": ["c"], "c": ["b"], "d": ["e"]}
+    root_nodes = ["a", "d"]
+    resolved = []
+    with pytest.raises(
+        ValueError, match=re.escape("circular dependency detected at node: b")
+    ):
+        _enumerate_dependencies(resolved=resolved, dependency_graph=graph, nodes=root_nodes)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -186,7 +186,5 @@ def test_enumerate_dependencies_with_circle():
     graph = {"a": ["b"], "b": ["c"], "c": ["b"], "d": ["e"]}
     root_nodes = ["a", "d"]
     resolved = []
-    with pytest.raises(
-        ValueError, match=re.escape("circular dependency detected at node: b")
-    ):
+    with pytest.raises(ValueError, match=re.escape("circular dependency detected at node: b")):
         _enumerate_dependencies(resolved=resolved, dependency_graph=graph, nodes=root_nodes)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3,7 +3,7 @@ import re
 
 import pytest
 
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
+from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, Span
 from pytorch_ie.core import AnnotationList, annotation_field
 from pytorch_ie.documents import TextDocument
 
@@ -43,6 +43,7 @@ def test_document_with_annotations():
         sentences: AnnotationList[Span] = annotation_field(target="text")
         entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
         relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+        label: AnnotationList[Label] = annotation_field()
 
     document1 = TestDocument(text="test1")
     assert isinstance(document1.sentences, AnnotationList)
@@ -82,7 +83,7 @@ def test_document_with_annotations():
 
     assert document1 == TestDocument.fromdict(document1.asdict())
 
-    assert len(document1) == 3
+    assert len(document1) == 4
     assert len(document1["sentences"]) == 2
     assert document1["sentences"][0].target == document1.text
 
@@ -104,12 +105,14 @@ def test_document_with_annotations():
     assert len(document1["sentences"].predictions) == 2
     assert document1["sentences"].predictions[1].target == document1.text
 
+    document1.label.append(Label(label="test_label", score=1.0))
+
     assert document1 == TestDocument.fromdict(document1.asdict())
 
     # number of annotation fields
-    assert len(document1) == 3
+    assert len(document1) == 4
     # actual annotation fields (tests __iter__)
-    assert set(document1) == {"sentences", "entities", "relations"}
+    assert set(document1) == {"sentences", "entities", "relations", "label"}
 
 
 def test_as_type():


### PR DESCRIPTION
This simplifies the annotation graph calculation and usage. Instead of saving `target -> source(s)` entries, we now save `source -> target(s)` (i.e. just the dependencies). This is possible by using `_enumerate_dependencies` (instead of `_depth_first_search`) which traverses the graph from sources to targets. A test for `_enumerate_dependencies` is included. Furthermore, this does not require a predefined `_root_annotation` field because we automatically add a node `_artificial_root` to the annotation graph that has all annotation fields that are not targeted as value.

This will also work with multiple base data elements, e.g. a text and an image, out of the box. It is also in preparation for having multiple targets per annotation field (see #210).

Note: This PR is an alternative to #207 (and it builds on top of it), i.e. it also fixes the handling of annotations that don't have any dependencies, i.e. dependent annotations.