### PR TITLE
[WIP] Simplify taskmodule

### DIFF
--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -157,9 +157,7 @@ class TaskModule(
                 # a document might be generated on the fly (e.g. with a Dataset), so we add it here
                 documents_in_order.append(document)
 
-            # TODO: revisit the assumption that encode_target=True always implies that
-            # is_training=True (we should get rid of the is_training parameter!)
-            possible_task_encodings = self.encode_input(document, is_training=encode_target)
+            possible_task_encodings = self.encode_input(document)
 
             # encode_input returns None or an empty list
             if possible_task_encodings is None or not possible_task_encodings:
@@ -170,7 +168,6 @@ class TaskModule(
 
             if encode_target:
                 for task_encoding in possible_task_encodings:
-                    # TODO: allow that encode_target can return None
                     targets = self.encode_target(task_encoding)
                     if targets is not None:
                         task_encoding.targets = targets
@@ -193,7 +190,6 @@ class TaskModule(
     def encode_input(
         self,
         document: DocumentType,
-        is_training: bool = False,
     ) -> Optional[
         Union[
             TaskEncoding[DocumentType, InputEncoding, TargetEncoding],
@@ -206,7 +202,7 @@ class TaskModule(
     def encode_target(
         self,
         task_encoding: TaskEncoding[DocumentType, InputEncoding, TargetEncoding],
-    ) -> TargetEncoding:
+    ) -> Optional[TargetEncoding]:
         pass
 
     @abstractmethod

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -256,18 +256,11 @@ class TaskModule(
                 for task_encoding in task_encodings
             ]
 
-        self.combine_outputs(task_encodings, task_outputs)
+        for task_encoding, task_output in zip(task_encodings, task_outputs):
+            self.combine_output(task_encoding, task_output)
 
         unique_documents = list(documents.values())
         return unique_documents
-
-    def combine_outputs(
-        self,
-        task_encodings: Sequence[TaskEncoding[DocumentType, InputEncoding, TargetEncoding]],
-        task_outputs: Sequence[TaskOutput],
-    ):
-        for task_encoding, task_output in zip(task_encodings, task_outputs):
-            self.combine_output(task_encoding, task_output)
 
     def combine_output(
         self,

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -175,7 +175,7 @@ class TaskModule(
                     if targets is not None:
                         task_encoding.targets = targets
                         task_encodings.append(task_encoding)
-                        #yield task_encoding
+                        # yield task_encoding
             else:
                 task_encodings.extend(possible_task_encodings)
 

--- a/src/pytorch_ie/taskmodules/transformer_seq2seq.py
+++ b/src/pytorch_ie/taskmodules/transformer_seq2seq.py
@@ -82,7 +82,6 @@ class TransformerSeq2SeqTaskModule(_TransformerSeq2SeqTaskModule):
     def encode_input(
         self,
         document: TextDocument,
-        is_training: bool = False,
     ) -> Optional[
         Union[
             TransformerSeq2SeqTaskEncoding,

--- a/src/pytorch_ie/taskmodules/transformer_span_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_span_classification.py
@@ -121,7 +121,6 @@ class TransformerSpanClassificationTaskModule(_TransformerSpanClassificationTask
     def encode_input(
         self,
         document: TextDocument,
-        is_training: bool = False,
     ) -> Optional[
         Union[
             TransformerSpanClassificationTaskEncoding,

--- a/src/pytorch_ie/taskmodules/transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_text_classification.py
@@ -128,7 +128,6 @@ class TransformerTextClassificationTaskModule(_TransformerTextClassificationTask
     def encode_input(
         self,
         document: TextDocument,
-        is_training: bool = False,
     ) -> Optional[
         Union[
             TransformerTextClassificationTaskEncoding,

--- a/src/pytorch_ie/taskmodules/transformer_token_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_token_classification.py
@@ -135,7 +135,6 @@ class TransformerTokenClassificationTaskModule(_TransformerTokenClassificationTa
     def encode_input(
         self,
         document: TextDocument,
-        is_training: bool = False,
     ) -> Optional[
         Union[
             TransformerTokenClassificationTaskEncoding,


### PR DESCRIPTION
This PR removes several methods from the taskmodule to simplify it and in preparation for #144 (note the plural s):  
* `encode_inputs`: content moved into `encode`
* `encode_targets`: content moved into `encode`
* `combine_outputs`: content moved into `decode`

It also removes the `is_training` parameter from `encode_input`. `encode_input` should not know and depend on that state. To allow some logic that includes certain examples depending on if we train/evaluate or just do inference, `encode_target` is allowed to return `None` in which case that task_encoding will not be added to the result of `encode` (the check happens only if parameter `encode_target=True`).

TODO:
* [ ] add general tests for taskmodule 
* [ ] add docstrings to taskmodule methods
