### PR TITLE
Iterable dataset

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -144,6 +144,18 @@ class Document(Mapping[str, Any]):
     )
     _annotation_fields: Set[str] = dataclasses.field(default_factory=set, init=False, repr=False)
 
+    @classmethod
+    def fields(cls):
+        return [
+            f
+            for f in dataclasses.fields(cls)
+            if f.name not in {"_annotation_graph", "_annotation_fields"}
+        ]
+
+    @classmethod
+    def annotation_fields(cls):
+        return _get_annotation_fields(list(dataclasses.fields(cls)))
+
     def __getitem__(self, key: str) -> AnnotationList:
         if key not in self._annotation_fields:
             raise KeyError(f"Document has no attribute '{key}'.")
@@ -184,9 +196,7 @@ class Document(Mapping[str, Any]):
 
     def asdict(self):
         dct = {}
-        for field in dataclasses.fields(self):
-            if field.name in {"_annotation_graph", "_annotation_fields"}:
-                continue
+        for field in self.fields():
 
             value = getattr(self, field.name)
 

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -19,7 +19,7 @@ from typing import (
 from pytorch_ie.core.document import Annotation, Document
 from pytorch_ie.core.hf_hub_mixin import PyTorchIETaskmoduleModelHubMixin
 from pytorch_ie.core.registrable import Registrable
-from pytorch_ie.data import Dataset
+from pytorch_ie.data import Dataset, IterableDataset
 
 """
 workflow:
@@ -139,7 +139,7 @@ class TaskModule(
 
     def encode(
         self,
-        documents: Union[DocumentType, Sequence[DocumentType], Dataset],
+        documents: Union[DocumentType, Sequence[DocumentType], Dataset, IterableDataset],
         encode_target: bool = False,
     ) -> Union[
         Sequence[TaskEncoding[DocumentType, InputEncoding, TargetEncoding]],
@@ -147,7 +147,7 @@ class TaskModule(
             TaskEncoding[DocumentType, InputEncoding, TargetEncoding], DocumentType
         ],
     ]:
-        if not isinstance(documents, (Sequence, Dataset)):
+        if not isinstance(documents, (Sequence, Dataset, IterableDataset)):
             documents = [documents]
 
         # TODO: revisit the assumption that encode_target=True always implies that
@@ -161,7 +161,7 @@ class TaskModule(
 
     def encode_inputs(
         self,
-        documents: Union[Sequence[DocumentType], Dataset],
+        documents: Union[Sequence[DocumentType], Dataset, IterableDataset],
         is_training: bool = False,
     ) -> Union[
         Sequence[TaskEncoding[DocumentType, InputEncoding, TargetEncoding]],

--- a/src/pytorch_ie/data/__init__.py
+++ b/src/pytorch_ie/data/__init__.py
@@ -3,7 +3,7 @@ from typing import Dict, Union
 from datasets import Split
 
 from .builder import GeneratorBasedBuilder
-from .dataset import Dataset
+from .dataset import Dataset, IterableDataset
 from .dataset_formatter import DocumentFormatter
 
 DatasetDict = Dict[Union[str, Split], Dataset]
@@ -11,6 +11,7 @@ DatasetDict = Dict[Union[str, Split], Dataset]
 __all__ = [
     "GeneratorBasedBuilder",
     "Dataset",
+    "IterableDataset",
     "DatasetDict",
     "DocumentFormatter",
 ]

--- a/src/pytorch_ie/data/builder.py
+++ b/src/pytorch_ie/data/builder.py
@@ -83,6 +83,9 @@ class GeneratorBasedBuilder(datasets.builder.GeneratorBasedBuilder):
             decorate_convert_to_dict_of_lists(self._generate_document), fn_kwargs=fn_kwargs
         )
 
+        if self.DOCUMENT_TYPE is None:
+            raise TypeError("the builder has no DOCUMENT_TYPE defined")
+
         document_dataset = Dataset.from_hf_dataset(
             mapped_dataset, document_type=self.DOCUMENT_TYPE
         )
@@ -100,6 +103,10 @@ class GeneratorBasedBuilder(datasets.builder.GeneratorBasedBuilder):
         if fn_kwargs is not None:
             fn = partial(fn, **fn_kwargs)
         mapped_dataset = dataset.map(fn)
+
+        if self.DOCUMENT_TYPE is None:
+            raise TypeError("the builder has no DOCUMENT_TYPE defined")
+
         return IterableDataset.from_hf_dataset(
             dataset=mapped_dataset, document_type=self.DOCUMENT_TYPE
         )

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -303,7 +303,7 @@ class IterableDataset(datasets.IterableDataset):
         for example in iter(super().__iter__()):
             yield self.document_type.fromdict(example)
 
-    def map(self, function: Optional[Callable] = None, batched: bool = False, **kwargs):  # type: ignore
+    def map(self, function: Optional[Callable] = None, batched: bool = False, **kwargs) -> "IterableDataset":  # type: ignore
         dataset_mapped = super().map(
             function=decorate_convert_to_document_and_back(
                 function, document_type=self.document_type, batched=batched

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -78,11 +78,13 @@ def _check_fields_for_casting(
 ) -> Tuple[Set[str], Set[str]]:
     original_fields = {
         # TODO: iterate over current_document_type.fields() instead to handling processing of non-annotation fields
-        field.name: field for field in _get_annotation_fields(list(fields(current_document_type)))
+        field.name: field
+        for field in _get_annotation_fields(list(fields(current_document_type)))
     }
     new_fields = {
-        # TODO: iterate over current_document_type.fields() instead to handling processing of non-annotation fields
-        field.name: field for field in _get_annotation_fields(list(fields(new_document_type)))
+        # TODO: iterate over new_document_type.fields() instead to handling processing of non-annotation fields
+        field.name: field
+        for field in _get_annotation_fields(list(fields(new_document_type)))
     }
     hidden_fields = set(column_names) - set(original_fields)
     fields_to_map_not_in_original_fields = (
@@ -155,7 +157,9 @@ class Dataset(datasets.Dataset):
         )
 
     @classmethod
-    def from_hf_dataset(cls, dataset: datasets.Dataset, document_type: Type[Document]) -> "Dataset":
+    def from_hf_dataset(
+        cls, dataset: datasets.Dataset, document_type: Type[Document]
+    ) -> "Dataset":
         document_dataset = cls(document_type=document_type, **cls.get_base_kwargs(dataset))
         return document_dataset
 

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -264,3 +264,11 @@ class IterableDataset(datasets.IterableDataset):
             **kwargs,
         )
         return IterableDataset.from_hf_dataset(dataset_mapped, document_type=self.document_type)
+
+    def cast_document_type(
+        self,
+        new_document_type: Type[D],
+        remove_columns: bool = False,
+        field_mapping: Optional[Dict[str, str]] = None,
+    ) -> "IterableDataset":
+        raise NotImplementedError("IterableDataset.cast_document_type() is not yet implemented")

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -190,3 +190,18 @@ class Dataset(datasets.Dataset):
         new_dataset = Dataset.from_hf_dataset(new_hf_dataset, document_type=new_document_type)
 
         return new_dataset
+
+
+class IterableDataset(datasets.IterableDataset):
+
+    def __init__(self, document_type: Type[Document], **kwargs):
+        super().__init__(**kwargs)
+
+        self.document_type = document_type
+        # TODO: this does not exist for IterableDataset
+        self.set_format("document", document_type=document_type)
+
+    @classmethod
+    def from_hf_dataset(cls, dataset: datasets.IterableDataset, document_type) -> "IterableDataset":
+        # TODO
+        pass

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -1,4 +1,3 @@
-from dataclasses import fields
 from functools import wraps
 from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, TypeVar, Union
 
@@ -6,7 +5,7 @@ import pandas as pd
 from datasets.formatting import _register_formatter
 
 import datasets
-from pytorch_ie.core.document import Document, _get_annotation_fields
+from pytorch_ie.core.document import Document
 from pytorch_ie.data.dataset_formatter import DocumentFormatter
 
 _register_formatter(DocumentFormatter, "document")
@@ -76,16 +75,8 @@ def _check_fields_for_casting(
     new_document_type: Type[Document],
     column_names: list[str],
 ) -> Tuple[Set[str], Set[str]]:
-    original_fields = {
-        # TODO: iterate over current_document_type.fields() instead to handling processing of non-annotation fields
-        field.name: field
-        for field in _get_annotation_fields(list(fields(current_document_type)))
-    }
-    new_fields = {
-        # TODO: iterate over new_document_type.fields() instead to handling processing of non-annotation fields
-        field.name: field
-        for field in _get_annotation_fields(list(fields(new_document_type)))
-    }
+    original_fields = {field.name: field for field in current_document_type.fields()}
+    new_fields = {field.name: field for field in new_document_type.fields()}
     hidden_fields = set(column_names) - set(original_fields)
     fields_to_map_not_in_original_fields = (
         set(field_mapping) - set(original_fields) - set(hidden_fields)

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -311,38 +311,6 @@ class IterableDataset(datasets.IterableDataset):
             hidden_columns=self.hidden_columns,
         )
 
-    def rename_columns(self, column_mapping: Dict[str, str]) -> "IterableDataset":
-        """
-        Rename several columns in the dataset, and move the features associated to the original columns under
-        the new column names.
-
-        Args:
-            column_mapping (:obj:`Dict[str, str]`): A mapping of columns to rename to their new names
-
-        Returns:
-            :class:`IterableDataset`: A copy of the dataset with renamed columns
-        """
-
-        def rename_columns_fn(example):
-            example = example.asdict()
-            if any(col not in example for col in column_mapping):
-                raise ValueError(
-                    f"Error when renaming {list(column_mapping)} to {list(column_mapping.values())}: "
-                    f"columns {set(column_mapping) - set(example)} are not in the dataset."
-                )
-            if any(col in example for col in column_mapping.values()):
-                raise ValueError(
-                    f"Error when renaming {list(column_mapping)} to {list(column_mapping.values())}: "
-                    f"columns {set(example) - set(column_mapping.values())} are already in the dataset."
-                )
-            renamed_example = {
-                new_column_name: example[original_column_name]
-                for original_column_name, new_column_name in column_mapping.items()
-            }
-            return self.document_type.fromdict(renamed_example)
-
-        return self.map(rename_columns_fn, remove_columns=list(column_mapping))
-
     def cast_document_type(
         self,
         new_document_type: Type[D],

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -230,7 +230,7 @@ class IterableDataset(datasets.IterableDataset):
         for example in iter(super().__iter__()):
             yield self.document_type.fromdict(example)
 
-    def map(self, function: Optional[Callable] = None, **kwargs):
+    def map(self, function: Optional[Callable] = None, **kwargs):  # type: ignore
         dataset_mapped = super().map(
             function=decorate_convert_to_document_and_back(
                 function, document_type=self.document_type

--- a/tests/data/test_dataset_casting.py
+++ b/tests/data/test_dataset_casting.py
@@ -184,8 +184,8 @@ def test_cast_document_type_rename_field(dataset_train):
 
 def test_cast_document_type_swap_fields(dataset_train):
     if isinstance(dataset_train, IterableDataset):
-        # TODO: for now, this would fail because IterableDataset.rename_columns() (copied from Huggingface)
-        #  is too restrictive
+        # TODO: for now, this would fail because datasets.IterableDataset.rename_columns() is too restrictive
+        #  (does not allow swapping)
         return
 
     # just add "parts" to have another field to swap "entities" with

--- a/tests/data/test_dataset_casting.py
+++ b/tests/data/test_dataset_casting.py
@@ -3,19 +3,10 @@ from dataclasses import dataclass
 
 import pytest
 
-import datasets
+from pytorch_ie import Dataset, IterableDataset
 from pytorch_ie.annotations import LabeledSpan, Span
 from pytorch_ie.core import AnnotationList, annotation_field
 from pytorch_ie.documents import TextDocument
-
-
-@pytest.fixture(scope="module")
-def conll2003_test_split():
-    # use test split since it is the smallest
-    return datasets.load_dataset(
-        path="pie/conll2003",
-        split="test",
-    )
 
 
 @dataclass
@@ -54,19 +45,40 @@ class DocumentWithPartsAndEntitiesSwapped(TextDocument):
     entities: AnnotationList[Span] = annotation_field(target="text")
 
 
+@pytest.fixture()
+def dataset_train(maybe_iterable_dataset):
+    return maybe_iterable_dataset["train"].cast_document_type(
+        CoNLL2002Document, remove_columns=True
+    )
+
+
 def _add_full_part(doc: DocumentWithParts) -> DocumentWithParts:
     doc.parts.append(Span(start=0, end=len(doc.text)))
     return doc
 
 
-def test_cast_document_type(conll2003_test_split):
-    casted = conll2003_test_split.cast_document_type(CoNLL2002WithPartsDocument)
+def _get_doc(ds):
+    # use the second document since it has entities
+    IDX = 2
+    if isinstance(ds, Dataset):
+        return ds[IDX]
+    elif isinstance(ds, IterableDataset):
+        it = iter(ds)
+        doc = None
+        for i in range(IDX + 1):
+            doc = next(it)
+        return doc
+
+
+def test_cast_document_type(dataset_train):
+    casted = dataset_train.cast_document_type(CoNLL2002WithPartsDocument)
+    doc0_orig = _get_doc(dataset_train)
     with_parts = casted.map(lambda doc: _add_full_part(doc))
     assert "entities" in with_parts.column_names
     assert "parts" in with_parts.column_names
-    doc0 = with_parts[0]
+    doc0 = _get_doc(with_parts)
     assert set(doc0) == {"entities", "parts"}
-    assert doc0.entities == conll2003_test_split[0].entities
+    assert doc0.entities == doc0_orig.entities
 
     part0 = doc0.parts[0]
     assert isinstance(part0, Span)
@@ -74,12 +86,13 @@ def test_cast_document_type(conll2003_test_split):
     assert part0.end == len(doc0.text)
 
 
-def test_cast_document_type_remove_field(conll2003_test_split):
-    casted = conll2003_test_split.cast_document_type(DocumentWithParts, remove_columns=True)
+def test_cast_document_type_remove_field(dataset_train):
+    doc0_orig = _get_doc(dataset_train)
+    casted = dataset_train.cast_document_type(DocumentWithParts, remove_columns=True)
     with_partitions = casted.map(lambda doc: _add_full_part(doc))
     assert "entities" not in with_partitions.column_names
     assert "parts" in with_partitions.column_names
-    doc0 = with_partitions[0]
+    doc0 = _get_doc(with_partitions)
     assert set(doc0) == {"parts"}
 
     part0 = doc0.parts[0]
@@ -90,36 +103,36 @@ def test_cast_document_type_remove_field(conll2003_test_split):
     casted_back = with_partitions.cast_document_type(CoNLL2002Document)
     assert "entities" in casted_back.column_names
     # original entities are not available anymore after casting back
-    assert len(conll2003_test_split[0].entities) > 0
-    assert len(casted_back[0].entities) == 0
+    assert len(doc0_orig.entities) > 0
+    assert len(list(casted_back)[0].entities) == 0
 
 
-def test_cast_document_type_recover_field(conll2003_test_split):
-    doc_orig = conll2003_test_split[0]
-    casted = conll2003_test_split.cast_document_type(DocumentWithParts)
+def test_cast_document_type_recover_field(dataset_train):
+    doc_orig = _get_doc(dataset_train)
+    casted = dataset_train.cast_document_type(DocumentWithParts)
     # "entities" stay in the arrow table because remove_columns=False per default
     assert "entities" in casted.column_names
     assert "parts" in casted.column_names
 
-    doc_casted = casted[0]
+    doc_casted = _get_doc(casted)
     assert set(doc_casted) == {"parts"}
 
     casted_back = casted.cast_document_type(CoNLL2002Document)
     assert "entities" in casted_back.column_names
     # original entities are recovered after casting back
-    doc_back = casted_back[0]
+    doc_back = _get_doc(casted_back)
     assert len(doc_back.entities) > 0
     assert doc_back.entities == doc_orig.entities
 
 
-def test_cast_document_type_recover_field_with_mapping(conll2003_test_split):
-    doc_orig = conll2003_test_split[0]
-    casted = conll2003_test_split.cast_document_type(DocumentWithParts)
+def test_cast_document_type_recover_field_with_mapping(dataset_train):
+    doc_orig = _get_doc(dataset_train)
+    casted = dataset_train.cast_document_type(DocumentWithParts)
     # "entities" stay in the arrow table because remove_columns=False per default
     assert "entities" in casted.column_names
     assert "parts" in casted.column_names
 
-    doc_casted = casted[0]
+    doc_casted = _get_doc(casted)
     assert set(doc_casted) == {"parts"}
 
     casted_back = casted.cast_document_type(
@@ -127,20 +140,19 @@ def test_cast_document_type_recover_field_with_mapping(conll2003_test_split):
     )
     assert "ents" in casted_back.column_names
     # original entities are recovered after casting back
-    doc_back = casted_back[0]
+    doc_back = _get_doc(casted_back)
     assert len(doc_back.ents) > 0
     assert doc_back.ents == doc_orig.entities
 
 
-def test_cast_document_type_recover_field_wrong(conll2003_test_split):
-    doc_orig = conll2003_test_split[0]
-    casted = conll2003_test_split.cast_document_type(DocumentWithEntsAndParts)
+def test_cast_document_type_recover_field_wrong(dataset_train):
+    casted = dataset_train.cast_document_type(DocumentWithEntsAndParts)
     # "entities" stay in the arrow table because remove_columns=False per default
     assert "entities" in casted.column_names
     assert "parts" in casted.column_names
     assert "ents" in casted.column_names
 
-    doc_casted = casted[0]
+    doc_casted = _get_doc(casted)
     assert set(doc_casted) == {"parts", "ents"}
 
     with pytest.raises(
@@ -152,16 +164,17 @@ def test_cast_document_type_recover_field_wrong(conll2003_test_split):
         casted.cast_document_type(CoNLL2002Document, field_mapping={"ents": "entities"})
 
 
-def test_cast_document_type_rename_field(conll2003_test_split):
-    casted = conll2003_test_split.cast_document_type(
+def test_cast_document_type_rename_field(dataset_train):
+    doc0_orig = _get_doc(dataset_train)
+    casted = dataset_train.cast_document_type(
         DocumentWithEntsAndParts, field_mapping={"entities": "ents"}
     )
     with_parts = casted.map(lambda doc: _add_full_part(doc))
     assert "ents" in with_parts.column_names
     assert "parts" in with_parts.column_names
-    doc0 = with_parts[0]
+    doc0 = _get_doc(with_parts)
     assert set(doc0) == {"ents", "parts"}
-    assert doc0.ents == conll2003_test_split[0].entities
+    assert doc0.ents == doc0_orig.entities
 
     part0 = doc0.parts[0]
     assert isinstance(part0, Span)
@@ -169,11 +182,16 @@ def test_cast_document_type_rename_field(conll2003_test_split):
     assert part0.end == len(doc0.text)
 
 
-def test_cast_document_type_swap_fields(conll2003_test_split):
+def test_cast_document_type_swap_fields(dataset_train):
+    if isinstance(dataset_train, IterableDataset):
+        # TODO: for now, this would fail because IterableDataset.rename_columns() (copied from Huggingface)
+        #  is too restrictive
+        return
+
     # just add "parts" to have another field to swap "entities" with
-    casted = conll2003_test_split.cast_document_type(CoNLL2002WithPartsDocument)
+    casted = dataset_train.cast_document_type(CoNLL2002WithPartsDocument)
     with_parts = casted.map(lambda doc: _add_full_part(doc))
-    doc_with_parts = with_parts[0]
+    doc_with_parts = _get_doc(with_parts)
 
     swapped = with_parts.cast_document_type(
         DocumentWithPartsAndEntitiesSwapped,
@@ -181,13 +199,13 @@ def test_cast_document_type_swap_fields(conll2003_test_split):
     )
     assert "entities" in swapped.column_names
     assert "parts" in swapped.column_names
-    doc_swapped = swapped[0]
+    doc_swapped = _get_doc(swapped)
     assert set(doc_swapped) == {"entities", "parts"}
     assert doc_swapped.parts == doc_with_parts.entities
     assert doc_swapped.entities == doc_with_parts.parts
 
 
-def test_cast_document_type_rename_source_not_available(conll2003_test_split):
+def test_cast_document_type_rename_source_not_available(dataset_train):
 
     with pytest.raises(
         ValueError,
@@ -195,12 +213,12 @@ def test_cast_document_type_rename_source_not_available(conll2003_test_split):
             "some fields to rename are not in the original document_type or hidden fields: {'not_in_original_document'}"
         ),
     ):
-        conll2003_test_split.cast_document_type(
+        dataset_train.cast_document_type(
             DocumentWithEntsWrongType, field_mapping={"not_in_original_document": "ents"}
         )
 
 
-def test_cast_document_type_rename_target_not_available(conll2003_test_split):
+def test_cast_document_type_rename_target_not_available(dataset_train):
 
     with pytest.raises(
         ValueError,
@@ -208,14 +226,14 @@ def test_cast_document_type_rename_target_not_available(conll2003_test_split):
             "some renamed fields are not in the new document_type: {'not_in_new_document'}"
         ),
     ):
-        conll2003_test_split.cast_document_type(
+        dataset_train.cast_document_type(
             DocumentWithEntsWrongType, field_mapping={"entities": "not_in_new_document"}
         )
 
 
-def test_cast_document_type_rename_wrong_type(conll2003_test_split):
+def test_cast_document_type_rename_wrong_type(dataset_train):
 
     with pytest.raises(ValueError, match=re.escape("new field is not the same as old field:")):
-        conll2003_test_split.cast_document_type(
+        dataset_train.cast_document_type(
             DocumentWithEntsWrongType, field_mapping={"entities": "ents"}
         )


### PR DESCRIPTION
This implements `IterableDataset` and allows to pass `streaming=True` to `load_dataset` to get one from any PIE dataset loading script. This is first step towards fully handling streamed datasets, see #144 for the related issue regarding the taskmodule.

Example usage (just works):
```python
import re
from dataclasses import dataclass

import datasets

from pytorch_ie.annotations import LabeledSpan, Span
from pytorch_ie.core import AnnotationList, annotation_field
from pytorch_ie.documents import TextDocument

@dataclass
class DocumentWithEntsAndSents(TextDocument):
    ents: AnnotationList[LabeledSpan] = annotation_field(target="text")
    sents: AnnotationList[Span] = annotation_field(target="text")

def add_sents_simple(doc: DocumentWithEntsAndSents):
    start = 0
    for match in re.finditer(r"\.", doc.text):
        doc.sents.append(Span(start=start, end=match.end()))
        start = match.end()
    return doc

# for this example, we take only the first two entries
ds_train = datasets.load_dataset("pie/conll2003", split="train", streaming=True).take(2)
ds_train_casted = ds_train.cast_document_type(DocumentWithEntsAndSents, field_mapping={"entities": "ents"})
ds_train_mapped = ds_train_casted.map(function=add_sents_simple)
for i, doc in enumerate(ds_train_mapped):
    print(f"doc")
    print(f"ents: {doc.ents}")
    print(f"sents: {doc.sents}")

# result:
# DocumentWithEntsAndSents(text='EU rejects German call to boycott British lamb .', id='0', metadata={})
# ents: AnnotationList([LabeledSpan(start=0, end=2, label='ORG', score=1.0), LabeledSpan(start=11, end=17, label='MISC', score=1.0), LabeledSpan(start=34, end=41, label='MISC', score=1.0)])
# sents: AnnotationList([Span(start=0, end=48)])
# DocumentWithEntsAndSents(text='Peter Blackburn', id='1', metadata={})
# ents: AnnotationList([LabeledSpan(start=0, end=15, label='PER', score=1.0)])
# sents: AnnotationList([])

```