### PR TITLE
is_from_pretrained property

### DIFF
--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -27,6 +27,14 @@ class PyTorchIEBaseModelHubMixin:
 
     config_name = CONFIG_NAME
 
+    def __init__(self, *args, is_from_pretrained: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._is_from_pretrained = is_from_pretrained
+
+    @property
+    def is_from_pretrained(self):
+        return self._is_from_pretrained
+
     def save_pretrained(
         self,
         save_directory: str,
@@ -174,6 +182,7 @@ class PyTorchIEBaseModelHubMixin:
             resume_download,
             local_files_only,
             use_auth_token,
+            is_from_pretrained=True,
             **config,
         )
 
@@ -317,6 +326,7 @@ class PyTorchIEModelHubMixin(PyTorchIEBaseModelHubMixin):
             >>> # Downloading weights from hf-hub & model will be initialized from those weights
             >>> model = MyModel.from_pretrained("username/mymodel@main")
         """
+        super().__init__(*args, **kwargs)
 
     def _save_pretrained(self, save_directory):
         """
@@ -397,7 +407,7 @@ class PyTorchIETaskmoduleModelHubMixin(PyTorchIEBaseModelHubMixin, Hyperparamete
             >>> # Downloading weights from hf-hub & model will be initialized from those weights
             >>> model = MyModel.from_pretrained("username/mymodel@main")
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
     def _config(self) -> Dict[str, Any]:
         config = dict(self.hparams)

--- a/src/pytorch_ie/core/model.py
+++ b/src/pytorch_ie/core/model.py
@@ -6,7 +6,7 @@ from pytorch_ie.core.hf_hub_mixin import PyTorchIEModelHubMixin
 from pytorch_ie.core.registrable import Registrable
 
 
-class PyTorchIEModel(LightningModule, Registrable, PyTorchIEModelHubMixin):
+class PyTorchIEModel(PyTorchIEModelHubMixin, LightningModule, Registrable):
     def _config(self) -> Dict[str, Any]:
         config = dict(self.hparams)
         this_class = self.__class__

--- a/src/pytorch_ie/models/transformer_seq2seq.py
+++ b/src/pytorch_ie/models/transformer_seq2seq.py
@@ -1,7 +1,7 @@
 from typing import Any, Sequence, Tuple
 
 import torch
-from transformers import AutoModelForSeq2SeqLM, BatchEncoding
+from transformers import AutoConfig, AutoModelForSeq2SeqLM, BatchEncoding
 from transformers.modeling_outputs import Seq2SeqLMOutput
 
 from pytorch_ie.core import PyTorchIEModel
@@ -25,7 +25,11 @@ class TransformerSeq2SeqModel(PyTorchIEModel):
 
         self.learning_rate = learning_rate
 
-        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
+        if self.is_from_pretrained:
+            config = AutoConfig.from_pretrained(model_name_or_path)
+            self.model = AutoModelForSeq2SeqLM.from_config(config=config)
+        else:
+            self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
 
     def forward(self, inputs: TransformerSeq2SeqModelBatchEncoding) -> TransformerSeq2SeqModelBatchOutput:  # type: ignore
         return self.model(**inputs)

--- a/src/pytorch_ie/models/transformer_seq2seq.py
+++ b/src/pytorch_ie/models/transformer_seq2seq.py
@@ -18,12 +18,8 @@ TransformerSeq2SeqModelStepBatchEncoding = Tuple[
 
 @PyTorchIEModel.register()
 class TransformerSeq2SeqModel(PyTorchIEModel):
-    def __init__(
-        self,
-        model_name_or_path: str,
-        learning_rate: float = 1e-5,
-    ) -> None:
-        super().__init__()
+    def __init__(self, model_name_or_path: str, learning_rate: float = 1e-5, **kwargs) -> None:
+        super().__init__(**kwargs)
 
         self.save_hyperparameters()
 

--- a/src/pytorch_ie/models/transformer_span_classification.py
+++ b/src/pytorch_ie/models/transformer_span_classification.py
@@ -41,8 +41,9 @@ class TransformerSpanClassificationModel(PyTorchIEModel):
         ignore_index: int = 0,
         max_span_length: int = 8,
         span_length_embedding_dim: int = 150,
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
         self.save_hyperparameters()
 
         self.t_total = t_total

--- a/src/pytorch_ie/models/transformer_span_classification.py
+++ b/src/pytorch_ie/models/transformer_span_classification.py
@@ -53,7 +53,10 @@ class TransformerSpanClassificationModel(PyTorchIEModel):
         self.max_span_length = max_span_length
 
         config = AutoConfig.from_pretrained(model_name_or_path)
-        self.model = AutoModel.from_pretrained(model_name_or_path, config=config)
+        if self.is_from_pretrained:
+            self.model = AutoModel.from_config(config=config)
+        else:
+            self.model = AutoModel.from_pretrained(model_name_or_path, config=config)
 
         classifier_dropout = (
             config.classifier_dropout

--- a/src/pytorch_ie/models/transformer_text_classification.py
+++ b/src/pytorch_ie/models/transformer_text_classification.py
@@ -44,7 +44,11 @@ class TransformerTextClassificationModel(PyTorchIEModel):
         self.warmup_proportion = warmup_proportion
 
         config = AutoConfig.from_pretrained(model_name_or_path)
-        self.model = AutoModel.from_pretrained(model_name_or_path, config=config)
+        if self.is_from_pretrained:
+            config = AutoConfig.from_pretrained(model_name_or_path)
+            self.model = AutoModel.from_config(config=config)
+        else:
+            self.model = AutoModel.from_pretrained(model_name_or_path, config=config)
         self.model.resize_token_embeddings(tokenizer_vocab_size)
 
         # if freeze_model:

--- a/src/pytorch_ie/models/transformer_text_classification.py
+++ b/src/pytorch_ie/models/transformer_text_classification.py
@@ -33,8 +33,9 @@ class TransformerTextClassificationModel(PyTorchIEModel):
         warmup_proportion: float = 0.1,
         freeze_model: bool = False,
         multi_label: bool = False,
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
         self.save_hyperparameters()
 
         self.t_total = t_total

--- a/src/pytorch_ie/models/transformer_token_classification.py
+++ b/src/pytorch_ie/models/transformer_token_classification.py
@@ -40,9 +40,13 @@ class TransformerTokenClassificationModel(PyTorchIEModel):
         self.num_classes = num_classes
 
         config = AutoConfig.from_pretrained(model_name_or_path, num_labels=num_classes)
-        self.model = AutoModelForTokenClassification.from_pretrained(
-            model_name_or_path, config=config
-        )
+        if self.is_from_pretrained:
+            config = AutoConfig.from_pretrained(model_name_or_path)
+            self.model = AutoModelForTokenClassification.from_config(config=config)
+        else:
+            self.model = AutoModelForTokenClassification.from_pretrained(
+                model_name_or_path, config=config
+            )
 
         self.f1 = nn.ModuleDict(
             {

--- a/src/pytorch_ie/models/transformer_token_classification.py
+++ b/src/pytorch_ie/models/transformer_token_classification.py
@@ -30,8 +30,9 @@ class TransformerTokenClassificationModel(PyTorchIEModel):
         learning_rate: float = 1e-5,
         label_pad_token_id: int = -100,
         ignore_index: int = 0,
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
         self.save_hyperparameters()
 
         self.learning_rate = learning_rate

--- a/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
@@ -150,8 +150,9 @@ class TransformerRETextClassificationTaskModule(_TransformerReTextClassification
         append_markers: bool = False,
         entity_labels: Optional[List[str]] = None,
         max_window: Optional[int] = None,
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
         self.save_hyperparameters()
 
         self.entity_annotation = entity_annotation

--- a/src/pytorch_ie/taskmodules/transformer_seq2seq.py
+++ b/src/pytorch_ie/taskmodules/transformer_seq2seq.py
@@ -56,8 +56,9 @@ class TransformerSeq2SeqTaskModule(_TransformerSeq2SeqTaskModule):
         max_input_length: Optional[int] = None,
         max_target_length: Optional[int] = None,
         pad_to_multiple_of: Optional[int] = None,
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
         self.save_hyperparameters()
 
         self.relation_annotation = relation_annotation

--- a/src/pytorch_ie/taskmodules/transformer_span_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_span_classification.py
@@ -64,8 +64,9 @@ class TransformerSpanClassificationTaskModule(_TransformerSpanClassificationTask
         label_pad_token_id: int = -100,
         label_to_id: Optional[Dict[str, int]] = None,
         multi_label: bool = False,
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
         self.save_hyperparameters()
 
         if multi_label:

--- a/src/pytorch_ie/taskmodules/transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_text_classification.py
@@ -83,8 +83,9 @@ class TransformerTextClassificationTaskModule(_TransformerTextClassificationTask
         pad_to_multiple_of: Optional[int] = None,
         multi_label: bool = False,
         label_to_id: Optional[Dict[str, int]] = None,
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
         self.save_hyperparameters()
 
         if multi_label:

--- a/src/pytorch_ie/taskmodules/transformer_token_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_token_classification.py
@@ -72,8 +72,9 @@ class TransformerTokenClassificationTaskModule(_TransformerTokenClassificationTa
         window_overlap: int = 0,
         show_statistics: bool = False,
         include_ill_formed_predictions: bool = True,
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
         self.save_hyperparameters()
 
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path)

--- a/tests/models/test_transformer_span_classification.py
+++ b/tests/models/test_transformer_span_classification.py
@@ -66,13 +66,16 @@ def mock_model(monkeypatch, documents, prepared_taskmodule):
         ),
     )
 
-    return TransformerSpanClassificationModel(
+    model = TransformerSpanClassificationModel(
         model_name_or_path="some-model-name",
         num_classes=num_classes,
         t_total=1,
         span_length_embedding_dim=15,
         max_span_length=2,
     )
+    assert not model.is_from_pretrained
+
+    return model
 
 
 @pytest.mark.parametrize("no_attention_mask", [False, True])

--- a/tests/pipeline/test_ner_span_classification.py
+++ b/tests/pipeline/test_ner_span_classification.py
@@ -20,7 +20,9 @@ class ExampleDocument(TextDocument):
 def test_ner_span_classification(fast_dev_run):
     model_name_or_path = "pie/example-ner-spanclf-conll03"
     ner_taskmodule = TransformerSpanClassificationTaskModule.from_pretrained(model_name_or_path)
+    assert ner_taskmodule.is_from_pretrained
     ner_model = TransformerSpanClassificationModel.from_pretrained(model_name_or_path)
+    assert ner_model.is_from_pretrained
 
     ner_pipeline = Pipeline(
         model=ner_model, taskmodule=ner_taskmodule, device=-1, fast_dev_run=fast_dev_run

--- a/tests/pipeline/test_re_text_classification.py
+++ b/tests/pipeline/test_re_text_classification.py
@@ -21,7 +21,9 @@ class ExampleDocument(TextDocument):
 def test_re_text_classification():
     model_name_or_path = "pie/example-re-textclf-tacred"
     re_taskmodule = TransformerRETextClassificationTaskModule.from_pretrained(model_name_or_path)
+    assert re_taskmodule.is_from_pretrained
     re_model = TransformerTextClassificationModel.from_pretrained(model_name_or_path)
+    assert re_model.is_from_pretrained
 
     pipeline = Pipeline(model=re_model, taskmodule=re_taskmodule, device=-1)
 

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -14,6 +14,8 @@ def taskmodule():
     taskmodule = TransformerRETextClassificationTaskModule(
         tokenizer_name_or_path=tokenizer_name_or_path
     )
+    assert not taskmodule.is_from_pretrained
+
     return taskmodule
 
 

--- a/tests/taskmodules/test_transformer_span_classification.py
+++ b/tests/taskmodules/test_transformer_span_classification.py
@@ -14,6 +14,8 @@ def taskmodule():
     taskmodule = TransformerSpanClassificationTaskModule(
         tokenizer_name_or_path=tokenizer_name_or_path
     )
+    assert not taskmodule.is_from_pretrained
+
     return taskmodule
 
 


### PR DESCRIPTION
This adds the property `is_from_pretrained` to all classes that inherit from `PyTorchIEBaseModelHubMixin`, especially to taskmodules and models. It allows, for instance, to load a model only from the huggingface hub, if it is really necessary. Previously, the model might be loaded twice from the hub: first when calling e.g. `AutoModel.from_pretrained` and then again in the init of the respective model which calls sth like `transformers.AutoModel.from_pretained`. Now we mitigate that with sth like:
```python
config = transformers.AutoConfig.from_pretrained(model_name_or_path)
if self.is_from_pretrained:
    self.model = transformers.AutoModel.from_config(config=config)
else:
    self.model = transformers.AutoModel.from_pretrained(model_name_or_path, config=config)
```
See also #114.

Note: To make `is_from_pretrained` available in the init methods of the respective child classes, they have to pass unknown kwargs to their super inits which is a breaking change. 