### PR TITLE
same annotations in different annotation lists

### DIFF
--- a/src/pytorch_ie/annotations.py
+++ b/src/pytorch_ie/annotations.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
-from pytorch_ie.core.document import Annotation
+from pytorch_ie.core.document import Annotation, T_annotation_store_key, resolve_annotation
 
 
 def _validate_single_label(self):
@@ -114,33 +114,21 @@ class BinaryRelation(Annotation):
 
     def asdict(self) -> Dict[str, Any]:
         dct = super().asdict()
-        dct["head"] = hash(self.head)
-        dct["tail"] = hash(self.tail)
+        dct["head"] = self.head.id
+        dct["tail"] = self.tail.id
         return dct
 
     @classmethod
     def fromdict(
         cls,
         dct: Dict[str, Any],
-        annotation_store: Optional[Dict[int, Tuple[str, "Annotation"]]] = None,
+        annotation_store: Optional[Dict[T_annotation_store_key, Tuple[str, "Annotation"]]] = None,
     ):
         tmp_dct = dict(dct)
         tmp_dct.pop("_id", None)
 
-        head = tmp_dct["head"]
-        tail = tmp_dct["tail"]
-
-        if isinstance(head, int):
-            if annotation_store is None:
-                raise ValueError("Unable to resolve head reference without annotation_store.")
-
-            tmp_dct["head"] = annotation_store[head][1]
-
-        if isinstance(tail, int):
-            if annotation_store is None:
-                raise ValueError("Unable to resolve tail reference without annotation_store.")
-
-            tmp_dct["tail"] = annotation_store[tail][1]
+        tmp_dct["head"] = resolve_annotation(tmp_dct["head"], store=annotation_store)
+        tmp_dct["tail"] = resolve_annotation(tmp_dct["tail"], store=annotation_store)
 
         return cls(**tmp_dct)
 
@@ -159,32 +147,20 @@ class MultiLabeledBinaryRelation(Annotation):
         dct = super().asdict()
 
         # replace object references with object hashes
-        dct["head"] = hash(self.head)
-        dct["tail"] = hash(self.tail)
+        dct["head"] = self.head.id
+        dct["tail"] = self.tail.id
         return dct
 
     @classmethod
     def fromdict(
         cls,
         dct: Dict[str, Any],
-        annotation_store: Optional[Dict[int, Tuple[str, "Annotation"]]] = None,
+        annotation_store: Optional[Dict[T_annotation_store_key, Tuple[str, "Annotation"]]] = None,
     ):
         tmp_dct = dict(dct)
         tmp_dct.pop("_id", None)
 
-        head = tmp_dct["head"]
-        tail = tmp_dct["tail"]
-
-        if isinstance(head, int):
-            if annotation_store is None:
-                raise ValueError("Unable to resolve head reference without annotation_store.")
-
-            tmp_dct["head"] = annotation_store[head][1]
-
-        if isinstance(tail, int):
-            if annotation_store is None:
-                raise ValueError("Unable to resolve tail reference without annotation_store.")
-
-            tmp_dct["tail"] = annotation_store[tail][1]
+        tmp_dct["head"] = resolve_annotation(tmp_dct["head"], store=annotation_store)
+        tmp_dct["tail"] = resolve_annotation(tmp_dct["tail"], store=annotation_store)
 
         return cls(**tmp_dct)

--- a/src/pytorch_ie/annotations.py
+++ b/src/pytorch_ie/annotations.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
-from pytorch_ie.core.document import Annotation, T_annotation_store_key, resolve_annotation
+from pytorch_ie.core.document import Annotation, resolve_annotation
 
 
 def _validate_single_label(self):
@@ -122,7 +122,7 @@ class BinaryRelation(Annotation):
     def fromdict(
         cls,
         dct: Dict[str, Any],
-        annotation_store: Optional[Dict[T_annotation_store_key, Tuple[str, "Annotation"]]] = None,
+        annotation_store: Optional[Dict[int, "Annotation"]] = None,
     ):
         tmp_dct = dict(dct)
         tmp_dct.pop("_id", None)
@@ -155,7 +155,7 @@ class MultiLabeledBinaryRelation(Annotation):
     def fromdict(
         cls,
         dct: Dict[str, Any],
-        annotation_store: Optional[Dict[T_annotation_store_key, Tuple[str, "Annotation"]]] = None,
+        annotation_store: Optional[Dict[int, "Annotation"]] = None,
     ):
         tmp_dct = dict(dct)
         tmp_dct.pop("_id", None)

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -15,7 +15,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import TypeAlias
+from typing_extensions import SupportsIndex, TypeAlias
 
 
 def _enumerate_dependencies(
@@ -96,6 +96,12 @@ class Annotation:
     TARGET_NAMES: ClassVar[Optional[Tuple[str, ...]]] = None
 
     def set_targets(self, value: Optional[Tuple[TARGET_TYPE, ...]]):
+        if value is not None and self._targets is not None:
+            raise ValueError(
+                f"Annotation already has assigned targets. Clear the "
+                f"annotation list container or remove the annotation with pop() "
+                f"to assign it to a new annotation list with other targets."
+            )
         object.__setattr__(self, "_targets", value)
 
     @property
@@ -196,6 +202,11 @@ class BaseAnnotationList(Sequence[T]):
         for annotation in self._annotations:
             annotation.set_targets(None)
         self._annotations = []
+
+    def pop(self, index=None):
+        ann = self._annotations.pop(index)
+        ann.set_targets(None)
+        return ann
 
 
 class AnnotationList(BaseAnnotationList[T]):

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -176,7 +176,7 @@ class BaseAnnotationList(Sequence[T]):
         return self._targets == other._targets and self._annotations == other._annotations
 
     def __hash__(self):
-        return hash(ann.id for ann in self._annotations)
+        return hash(tuple(self._targets) + tuple(ann.id for ann in self._annotations))
 
     @overload
     def __getitem__(self, index: int) -> T:

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -107,7 +107,13 @@ class Annotation:
     @property
     def id(self) -> int:
         if self.targets is not None:
-            return hash((self,) + self.targets)
+            # Take the hash from itself and all targets that are no annotation lists since
+            # the relevant entries of annotation lists are already referenced, and thus hashed,
+            # in the annotation itself.
+            non_annotationlist_targets = tuple(
+                target for target in self.targets if not isinstance(target, AnnotationList)
+            )
+            return hash((self,) + non_annotationlist_targets)
         else:
             return hash(self)
 

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -175,9 +175,6 @@ class BaseAnnotationList(Sequence[T]):
 
         return self._targets == other._targets and self._annotations == other._annotations
 
-    def __hash__(self):
-        return hash(tuple(self._targets) + tuple(ann.id for ann in self._annotations))
-
     @overload
     def __getitem__(self, index: int) -> T:
         ...
@@ -229,9 +226,6 @@ class AnnotationList(BaseAnnotationList[T]):
             return NotImplemented
 
         return super().__eq__(other) and self.predictions == other.predictions
-
-    def __hash__(self):
-        return hash((super().__hash__(), hash(self._predictions)))
 
     def __repr__(self) -> str:
         return f"AnnotationList({str(self._annotations)})"

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -28,7 +28,7 @@ def test_label():
     assert label2.score == pytest.approx(0.5)
 
     assert label2.asdict() == {
-        "_id": hash(label2),
+        "_id": label2.id,
         "label": "label2",
         "score": 0.5,
     }
@@ -46,7 +46,7 @@ def test_multilabel():
     assert multilabel2.score == pytest.approx((0.4, 0.5))
 
     multilabel2.asdict() == {
-        "_id": hash(multilabel2),
+        "_id": multilabel2.id,
         "label": ("label3", "label4"),
         "score": (0.4, 0.5),
     }
@@ -65,7 +65,7 @@ def test_span():
     assert span.end == 2
 
     span.asdict() == {
-        "_id": hash(span),
+        "_id": span.id,
         "start": 1,
         "end": 2,
     }
@@ -87,7 +87,7 @@ def test_labeled_span():
     assert labeled_span2.score == pytest.approx(0.5)
 
     labeled_span2.asdict() == {
-        "_id": hash(labeled_span2),
+        "_id": labeled_span2.id,
         "label": ("label3", "label4"),
         "score": (0.4, 0.5),
     }
@@ -111,7 +111,7 @@ def test_multilabeled_span():
     assert multilabeled_span2.score == pytest.approx((0.4, 0.5))
 
     multilabeled_span2.asdict() == {
-        "_id": hash(multilabeled_span2),
+        "_id": multilabeled_span2.id,
         "start": 3,
         "end": 4,
         "label": ("label3", "label4"),
@@ -142,7 +142,7 @@ def test_labeled_multi_span():
     assert labeled_multi_span2.score == pytest.approx(0.5)
 
     labeled_multi_span2.asdict() == {
-        "_id": hash(labeled_multi_span2),
+        "_id": labeled_multi_span2.id,
         "slices": ((5, 6), (7, 8)),
         "label": "label2",
         "score": 0.5,
@@ -167,7 +167,7 @@ def test_multilabeled_multi_span():
     assert multilabeled_multi_span2.score == pytest.approx((0.4, 0.5))
 
     multilabeled_multi_span2.asdict() == {
-        "_id": hash(multilabeled_multi_span2),
+        "_id": multilabeled_multi_span2.id,
         "slices": ((5, 6), (7, 8)),
         "label": ("label2", "label3"),
         "score": (0.4, 0.5),
@@ -202,23 +202,24 @@ def test_binary_relation():
     assert binary_relation2.score == pytest.approx(0.5)
 
     binary_relation2.asdict() == {
-        "_id": hash(binary_relation2),
-        "head": hash(head),
-        "tail": hash(tail),
+        "_id": binary_relation2.id,
+        "head": head.id,
+        "tail": head.id,
         "label": "label2",
         "score": 0.5,
     }
 
     annotation_store = {
-        hash(head): ("head", head),
-        hash(tail): ("tail", tail),
+        head.id: ("head", head),
+        tail.id: ("tail", tail),
     }
     binary_relation2 == BinaryRelation.fromdict(
         binary_relation2.asdict(), annotation_store=annotation_store
     )
 
     with pytest.raises(
-        ValueError, match=re.escape("Unable to resolve head reference without annotation_store.")
+        ValueError,
+        match=re.escape("Unable to resolve the annotation id without annotation_store."),
     ):
         binary_relation2 == BinaryRelation.fromdict(binary_relation2.asdict())
 
@@ -242,23 +243,24 @@ def test_multilabeled_binary_relation():
     assert binary_relation2.score == pytest.approx((0.4, 0.5))
 
     binary_relation2.asdict() == {
-        "_id": hash(binary_relation2),
-        "head": hash(head),
-        "tail": hash(tail),
+        "_id": binary_relation2.id,
+        "head": head.id,
+        "tail": tail.id,
         "label": ("label3", "label4"),
         "score": (0.4, 0.5),
     }
 
     annotation_store = {
-        hash(head): ("head", head),
-        hash(tail): ("tail", tail),
+        head.id: ("head", head),
+        tail.id: ("tail", tail),
     }
     binary_relation2 == MultiLabeledBinaryRelation.fromdict(
         binary_relation2.asdict(), annotation_store=annotation_store
     )
 
     with pytest.raises(
-        ValueError, match=re.escape("Unable to resolve head reference without annotation_store.")
+        ValueError,
+        match=re.escape("Unable to resolve the annotation id without annotation_store."),
     ):
         binary_relation2 == MultiLabeledBinaryRelation.fromdict(binary_relation2.asdict())
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -210,8 +210,8 @@ def test_binary_relation():
     }
 
     annotation_store = {
-        head.id: ("head", head),
-        tail.id: ("tail", tail),
+        head.id: head,
+        tail.id: tail,
     }
     binary_relation2 == BinaryRelation.fromdict(
         binary_relation2.asdict(), annotation_store=annotation_store
@@ -251,8 +251,8 @@ def test_multilabeled_binary_relation():
     }
 
     annotation_store = {
-        head.id: ("head", head),
-        tail.id: ("tail", tail),
+        head.id: head,
+        tail.id: tail,
     }
     binary_relation2 == MultiLabeledBinaryRelation.fromdict(
         binary_relation2.asdict(), annotation_store=annotation_store

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -110,7 +110,10 @@ def test_document_with_annotations():
     document1.sentences.predictions.append(span3)
     document1.sentences.predictions.append(span4)
     # add a prediction that is also an annotation
-    document1.entities.predictions.append(labeled_span1)
+    # remove the annotation to allow reassigning it
+    relation1_popped = document1.relations.pop(0)
+    assert relation1_popped == relation1
+    document1.relations.predictions.append(relation1)
 
     assert len(document1.sentences.predictions) == 2
     assert document1.sentences.predictions[1].target == document1.text

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -127,6 +127,24 @@ def test_document_with_annotations():
     assert set(document1) == {"sentences", "entities", "relations", "label"}
 
 
+def test_document_with_same_annotations():
+    @dataclasses.dataclass
+    class TestDocument(TextDocument):
+        tokens: AnnotationList[Span] = annotation_field(target="text")
+        sentences: AnnotationList[Span] = annotation_field(target="text")
+
+    doc = TestDocument(text="test1")
+    token = Span(start=0, end=len(doc.text))
+    sentence = Span(start=0, end=len(doc.text))
+    doc.tokens.append(token)
+    doc.sentences.append(sentence)
+
+    doc_dict = doc.asdict()
+
+    doc_reconstructed = TestDocument.fromdict(doc_dict)
+    assert doc == doc_reconstructed
+
+
 def test_as_type():
     @dataclasses.dataclass
     class TestDocument1(TextDocument):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -88,6 +88,10 @@ def test_document_with_annotations():
     assert document1.sentences[0].target == document1.text
 
     relation1 = BinaryRelation(head=labeled_span1, tail=labeled_span2, label="label1")
+    relation2 = BinaryRelation(head=labeled_span1, tail=labeled_span2, label="label1")
+    relation3 = BinaryRelation(head=labeled_span2, tail=labeled_span1, label="label1")
+    assert relation1.id == relation2.id
+    assert relation1.id != relation3.id
 
     document1.relations.append(relation1)
     assert len(document1.relations) == 1
@@ -132,18 +136,53 @@ def test_document_with_annotations():
 
 def test_document_with_same_annotations():
     @dataclasses.dataclass
-    class TestDocument(TextDocument):
-        tokens: AnnotationList[Span] = annotation_field(target="text")
-        sentences: AnnotationList[Span] = annotation_field(target="text")
+    class TestDocument(Document):
+        text: str
+        text2: str
+        text3: str
+        tokens0: AnnotationList[Span] = annotation_field(target="text")
+        tokens1: AnnotationList[Span] = annotation_field(target="text")
+        tokens2: AnnotationList[Span] = annotation_field(target="text2")
+        tokens3: AnnotationList[Span] = annotation_field(target="text3")
 
-    doc = TestDocument(text="test1")
-    token = Span(start=0, end=len(doc.text))
-    sentence = Span(start=0, end=len(doc.text))
-    doc.tokens.append(token)
-    doc.sentences.append(sentence)
+    doc = TestDocument(text="test1", text2="test1", text3="test2")
+    start = 0
+    end = len(doc.text)
+    token0 = Span(start=start, end=end)
+    token1 = Span(start=start, end=end)
+    token2 = Span(start=start, end=end)
+    token3 = Span(start=start, end=end)
+    token0_id = token0.id
+    token1_id = token1.id
+    token2_id = token2.id
+    token3_id = token3.id
+    # all spans are identical, so are there ids
+    assert token1_id == token0_id
+    assert token2_id == token0_id
+    assert token3_id == token0_id
+    doc.tokens0.append(token0)
+    doc.tokens1.append(token1)
+    doc.tokens2.append(token2)
+    doc.tokens3.append(token3)
+    token0_id_added = token0.id
+    token1_id_added = token1.id
+    token2_id_added = token2.id
+    token3_id_added = token3.id
+    # after adding them to a document, the targets are taken into account, so their id changed
+    assert token0_id_added != token0_id
+    assert token1_id_added != token1_id
+    assert token2_id_added != token2_id
+    assert token3_id_added != token3_id
 
+    # token0 and token1 spans are still identical because they have the same target
+    assert token0_id_added == token1_id_added
+    # they are also still identical with token2 because they have the same target content (!)
+    assert token2_id_added == token0_id_added
+    # teh differ from token3 because their target content (!) is different
+    assert token3_id_added != token0_id_added
+
+    # test reconstruction
     doc_dict = doc.asdict()
-
     doc_reconstructed = TestDocument.fromdict(doc_dict)
     assert doc == doc_reconstructed
 


### PR DESCRIPTION
Example:
```python
@dataclasses.dataclass
class TestDocument(TextDocument):
    tokens: AnnotationList[Span] = annotation_field(target="text")
    sentences: AnnotationList[Span] = annotation_field(target="text")

doc = TestDocument(text="test1")
# per coincidence, the token and the sentence are the same
token = Span(start=0, end=len(doc.text))
sentence = Span(start=0, end=len(doc.text))
# note, that we add them to the respective fields 
doc.tokens.append(token)
doc.sentences.append(sentence)

doc_dict = doc.asdict()

doc_reconstructed = TestDocument.fromdict(doc_dict)
print(doc_reconstructed.sentences)
# AnnotationList([Span(start=0, end=5)])
print(doc_reconstructed.tokens)
# AnnotationList([])
assert doc == doc_reconstructed
```

Before this PR, this failed, because the annotation names were not taken into account when collecting the annotations for reconstruction. See the outcome of `doc_reconstructed.sentences` and `doc_reconstructed.tokens` in the example code above.

In addition to fixing the described bug, this PR does the following changes to mitigate further errors:
* add `Annotation.id`as unique identifier. It is used as `_id` in `asdict()` and depends on the own hash and the hashes of all targets that are _no_ annotation lists, if targets are available at all. If an annotation targets an annotation list, the relevant entries are directly referenced, and thus hashed, within the annotation, so there is no need to hash the whole annotation list to get a unique identifier.
* add a helper function `resolve_annotation` that converts an annotation id to the actual annotation with help of an annotation store
* add `AnnotationList.pop(index=None)` to remove an annotation (this also resets the targets to `None`)
* disallow to re-set annotation targets (`None` is still allowed) to mitigate errors. `AnnotationList.clear()` or `AnnotationList.pop(index)` can be used to free annotations again. 
