### PR TITLE
result_document_type for (Iterable)Dataset.map()

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -392,7 +392,9 @@ class Document(Mapping[str, Any]):
 
         return doc
 
-    def as_type(self, new_type: typing.Type[D], field_mapping: Optional[Dict[str, str]] = None):
+    def as_type(
+        self, new_type: typing.Type[D], field_mapping: Optional[Dict[str, str]] = None
+    ) -> D:
         field_mapping = field_mapping or {}
         new_doc = new_type.fromdict({field_mapping.get(k, k): v for k, v in self.asdict().items()})
         return new_doc

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -221,7 +221,7 @@ class Dataset(datasets.Dataset):
         )
 
         if result_document_type is None:
-            if function is not None:
+            if function is not None and as_documents:
                 result_document_type = _infer_document_type_from_function_return(function=function)
             if result_document_type is None:
                 result_document_type = self.document_type
@@ -318,19 +318,22 @@ class IterableDataset(datasets.IterableDataset):
         self,
         function: Optional[Callable] = None,
         batched: bool = False,
+        as_documents: bool = True,
         result_document_type: Optional[Type[Document]] = None,
         **kwargs,
     ) -> "IterableDataset":
         dataset_mapped = super().map(
             function=decorate_convert_to_document_and_back(
                 function, document_type=self.document_type, batched=batched
-            ),
+            )
+            if as_documents
+            else function,
             batched=batched,
             **kwargs,
         )
 
         if result_document_type is None:
-            if function is not None:
+            if function is not None and as_documents:
                 result_document_type = _infer_document_type_from_function_return(function=function)
             if result_document_type is None:
                 result_document_type = self.document_type

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -117,7 +117,7 @@ def _check_fields_for_casting(
 D = TypeVar("D", bound=Document)
 
 
-def _infer_document_type_from_function_return(function: Callable, default: Type[D]) -> Type[D]:
+def _infer_document_type_from_function_return(function: Callable) -> Optional[Type[Document]]:
     # try to infer the document type from the return type annotation of function
     return_signature = signature(function).return_annotation
     if not return_signature == Signature.empty:
@@ -126,7 +126,7 @@ def _infer_document_type_from_function_return(function: Callable, default: Type[
                 f"the return type annotation of the function used with map is not a subclass of Document"
             )
         return return_signature
-    return default
+    return None
 
 
 class Dataset(datasets.Dataset):
@@ -221,9 +221,10 @@ class Dataset(datasets.Dataset):
         )
 
         if result_document_type is None:
-            result_document_type = _infer_document_type_from_function_return(
-                function=function, default=self.document_type
-            )
+            if function is not None:
+                result_document_type = _infer_document_type_from_function_return(function=function)
+            if result_document_type is None:
+                result_document_type = self.document_type
 
         return Dataset.from_hf_dataset(dataset, document_type=result_document_type)
 
@@ -329,9 +330,10 @@ class IterableDataset(datasets.IterableDataset):
         )
 
         if result_document_type is None:
-            result_document_type = _infer_document_type_from_function_return(
-                function=function, default=self.document_type
-            )
+            if function is not None:
+                result_document_type = _infer_document_type_from_function_return(function=function)
+            if result_document_type is None:
+                result_document_type = self.document_type
 
         return IterableDataset.from_hf_dataset(dataset_mapped, document_type=result_document_type)
 

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Dict, Sequence
 
 import numpy
 import pytest
@@ -108,7 +108,8 @@ def test_dataset_map_batched(maybe_iterable_dataset):
     assert sum(len(doc.relations) for doc in train_dataset) == 7
 
 
-def test_dataset_map_with_result_document_type(maybe_iterable_dataset):
+@pytest.mark.parametrize("infer_type", [False, True])
+def test_dataset_map_with_result_document_type(maybe_iterable_dataset, infer_type):
     @dataclass
     class TestDocument(TextDocument):
         sentences: AnnotationList[Span] = annotation_field(target="text")
@@ -116,33 +117,54 @@ def test_dataset_map_with_result_document_type(maybe_iterable_dataset):
         relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
 
     @dataclass
-    class TestDocumentWithoutRelations(TextDocument):
+    class TestDocumentWithTokensButNoRelations(TextDocument):
         sentences: AnnotationList[Span] = annotation_field(target="text")
+        tokens: AnnotationList[Span] = annotation_field(target="text")
         entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
 
-    def clear_relations(document: TestDocument) -> TestDocumentWithoutRelations:
+    def clear_relations_and_add_one_token(
+        document: TestDocument,
+    ) -> TestDocumentWithTokensButNoRelations:
         document.relations.clear()
         # the conversion here is not really necessary, but to have correct typing
-        return document.as_type(TestDocumentWithoutRelations)
+        result = document.as_type(TestDocumentWithTokensButNoRelations)
+        result.tokens.append(Span(0, len(document.text)))
+        return result
 
     train_dataset = maybe_iterable_dataset["train"]
 
     assert sum(len(doc.relations) for doc in train_dataset) == 7
 
     mapped_dataset1 = train_dataset.map(
-        clear_relations, result_document_type=TestDocumentWithoutRelations
+        clear_relations_and_add_one_token,
+        result_document_type=TestDocumentWithTokensButNoRelations if not infer_type else None,
     )
 
     assert sum(len(doc.relations) for doc in train_dataset) == 7
 
     doc0 = list(train_dataset)[0]
     doc0_mapped = list(mapped_dataset1)[0]
+    assert len(doc0_mapped.tokens) == 1
+    token = doc0_mapped.tokens[0]
+    assert token.start == 0
+    assert token.end == len(doc0.text)
     # check field names because isinstance does not work (the code of the document types
     # is the same, but lives at different locations)
     assert {f.name for f in doc0.fields()} == {f.name for f in TestDocument.fields()}
     assert {f.name for f in doc0_mapped.fields()} == {
-        f.name for f in TestDocumentWithoutRelations.fields()
+        f.name for f in TestDocumentWithTokensButNoRelations.fields()
     }
+
+    if infer_type:
+
+        def func_wrong_return_type(document: TestDocument) -> Dict:
+            return document  # type: ignore
+
+        with pytest.raises(
+            TypeError,
+            match="the return type annotation of the function used with map is not a subclass of Document",
+        ):
+            train_dataset.map(func_wrong_return_type)
 
 
 @pytest.mark.parametrize("encode_target", [False, True])

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -128,6 +128,8 @@ def test_dataset_map_with_result_document_type(maybe_iterable_dataset, infer_typ
         document.relations.clear()
         # the conversion here is not really necessary, but to have correct typing
         result = document.as_type(TestDocumentWithTokensButNoRelations)
+        # subtract 1 to create a Span different from the sentence to account for
+        # https://github.com/ChristophAlt/pytorch-ie/pull/222
         result.tokens.append(Span(0, len(document.text) - 1))
         return result
 

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -128,7 +128,7 @@ def test_dataset_map_with_result_document_type(maybe_iterable_dataset, infer_typ
         document.relations.clear()
         # the conversion here is not really necessary, but to have correct typing
         result = document.as_type(TestDocumentWithTokensButNoRelations)
-        result.tokens.append(Span(0, len(document.text)))
+        result.tokens.append(Span(0, len(document.text) - 1))
         return result
 
     train_dataset = maybe_iterable_dataset["train"]
@@ -147,7 +147,7 @@ def test_dataset_map_with_result_document_type(maybe_iterable_dataset, infer_typ
     assert len(doc0_mapped.tokens) == 1
     token = doc0_mapped.tokens[0]
     assert token.start == 0
-    assert token.end == len(doc0.text)
+    assert token.end == len(doc0.text) - 1
     # check field names because isinstance does not work (the code of the document types
     # is the same, but lives at different locations)
     assert {f.name for f in doc0.fields()} == {f.name for f in TestDocument.fields()}


### PR DESCRIPTION
This PR adds an optional parameter `document_return_type` to `(Iterable)Dataset`. This is useful if the mapped function returns documents of a different type. Furthermore, `document_return_type` will be inferred from the function return type annotation if possible and no `document_return_type` is explicitly provided.