### PR TITLE
remove parameter predict_field from pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ document = ExampleDocument(
 # see below for the long version
 ner_pipeline = AutoPipeline.from_pretrained("pie/example-ner-spanclf-conll03", device=-1, num_workers=0)
 
-ner_pipeline(document, predict_field="entities")
+ner_pipeline(document)
 
 for entity in document.entities.predictions:
     print(f"{entity} -> {entity.label}")
@@ -150,7 +150,7 @@ re_pipeline = AutoPipeline.from_pretrained("pie/example-re-textclf-tacred", devi
 for start, end, label in [(65, 75, "PER"), (96, 100, "ORG"), (126, 134, "ORG")]:
     document.entities.append(LabeledSpan(start=start, end=end, label=label))
 
-re_pipeline(document, predict_field="relations", batch_size=2)
+re_pipeline(document, batch_size=2)
 
 for relation in document.relations.predictions:
     print(f"({relation.head} -> {relation.tail}) -> {relation.label}")

--- a/examples/predict/ner_span_classification.py
+++ b/examples/predict/ner_span_classification.py
@@ -24,7 +24,7 @@ def main():
         "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
     )
 
-    ner_pipeline(document, predict_field="entities")
+    ner_pipeline(document)
 
     for entity in document.entities.predictions:
         print(f"{entity} -> {entity.label}")

--- a/examples/predict/re_generative.py
+++ b/examples/predict/re_generative.py
@@ -33,7 +33,7 @@ def main():
         "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
     )
 
-    pipeline(document, predict_field="relations")
+    pipeline(document)
 
     for relation in document.relations.predictions:
         print(f"({relation.head} -> {relation.tail}) -> {relation.label}")

--- a/examples/predict/re_text_classification.py
+++ b/examples/predict/re_text_classification.py
@@ -28,7 +28,7 @@ def main():
     for start, end, label in [(65, 75, "PER"), (96, 100, "ORG"), (126, 134, "ORG")]:
         document.entities.append(LabeledSpan(start=start, end=end, label=label))
 
-    re_pipeline(document, predict_field="relations", batch_size=2)
+    re_pipeline(document, batch_size=2)
 
     for relation in document.relations.predictions:
         print(f"({relation.head} -> {relation.tail}) -> {relation.label}")

--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -166,7 +166,7 @@ class Pipeline:
         _sanitize_parameters will be called with any excessive named arguments from either `__init__` or `__call__`
         methods. It should return 4 dictionaries of the resolved parameters used by the various `preprocess`,
         `get_dataloader`, `forward` and `postprocess` methods. Do not fill dictionaries if the caller didn't specify
-        a kwargs. This let's you keep defaults in function signatures, which is more "natural".
+        a kwargs. This lets you keep defaults in function signatures, which is more "natural".
 
         It is not meant to be called directly, it will be automatically called and the final parameters resolved by
         `__init__` and `__call__`
@@ -177,9 +177,9 @@ class Pipeline:
         postprocess_parameters: Dict[str, Any] = {}
 
         # set preprocess parameters
-        field = pipeline_parameters.get("predict_field")
-        if field:
-            preprocess_parameters["predict_field"] = field
+        for p_name in []:
+            if p_name in pipeline_parameters:
+                preprocess_parameters[p_name] = pipeline_parameters[p_name]
 
         # set forward parameters
         for p_name in ["show_progress_bar", "fast_dev_run"]:
@@ -201,16 +201,12 @@ class Pipeline:
     def preprocess(
         self,
         documents: Union[Sequence[Document], Dataset],
-        predict_field: str,
         **preprocess_parameters: Dict,
     ) -> Sequence[TaskEncoding]:
         """
         Preprocess will take the `input_` of a specific pipeline and return a dictionnary of everything necessary for
         `_forward` to run properly. It should contain at least one tensor, but might have arbitrary other items.
         """
-
-        for document in documents:
-            document[predict_field].predictions.clear()
 
         encodings = self.taskmodule.encode(
             documents, encode_target=False, as_task_encoding_sequence=True

--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -3,7 +3,7 @@ import os
 import warnings
 from collections import UserDict
 from contextlib import contextmanager
-from typing import Any, Dict, List, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 import tqdm
@@ -177,7 +177,7 @@ class Pipeline:
         postprocess_parameters: Dict[str, Any] = {}
 
         # set preprocess parameters
-        for p_name in []:
+        for p_name in ["document_batch_size"]:
             if p_name in pipeline_parameters:
                 preprocess_parameters[p_name] = pipeline_parameters[p_name]
 
@@ -201,6 +201,7 @@ class Pipeline:
     def preprocess(
         self,
         documents: Union[Sequence[Document], Dataset],
+        document_batch_size: Optional[int] = None,
         **preprocess_parameters: Dict,
     ) -> Sequence[TaskEncoding]:
         """
@@ -209,7 +210,10 @@ class Pipeline:
         """
 
         encodings = self.taskmodule.encode(
-            documents, encode_target=False, as_task_encoding_sequence=True
+            documents,
+            encode_target=False,
+            as_task_encoding_sequence=True,
+            document_batch_size=document_batch_size,
         )
         if not isinstance(encodings, Sequence):
             raise TypeError("preprocess has to return a sequence")

--- a/tests/pipeline/test_ner_span_classification.py
+++ b/tests/pipeline/test_ner_span_classification.py
@@ -30,7 +30,7 @@ def test_ner_span_classification(fast_dev_run):
 
     text = "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
     documents = [ExampleDocument(text), ExampleDocument(text), ExampleDocument(text)]
-    ner_pipeline(documents, predict_field="entities", batch_size=2)
+    ner_pipeline(documents, batch_size=2)
 
     for i, document in enumerate(documents):
         entities = document.entities.predictions

--- a/tests/pipeline/test_re_generative.py
+++ b/tests/pipeline/test_re_generative.py
@@ -36,7 +36,7 @@ def test_re_generative():
         "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
     )
 
-    pipeline(document, predict_field="relations", batch_size=2)
+    pipeline(document, batch_size=2)
 
     relations = document.relations.predictions
     assert len(relations) == 2

--- a/tests/pipeline/test_re_text_classification.py
+++ b/tests/pipeline/test_re_text_classification.py
@@ -34,7 +34,7 @@ def test_re_text_classification():
     for start, end, label in [(65, 75, "PER"), (96, 100, "ORG"), (126, 134, "ORG")]:
         document.entities.append(LabeledSpan(start=start, end=end, label=label))
 
-    pipeline(document, predict_field="relations", batch_size=2)
+    pipeline(document, batch_size=2)
     relations: Sequence[BinaryRelation] = document["relations"].predictions
     assert len(relations) == 4
 

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -67,7 +67,7 @@ def test_auto_pipeline():
         "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
     )
 
-    pipeline(document, predict_field="entities", num_workers=0)
+    pipeline(document, num_workers=0)
 
     entities = document.entities.predictions
     assert len(entities) == 3

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -91,7 +91,7 @@ def test_pipeline_with_document(documents, prepared_taskmodule, mock_model, inpl
     document = documents[1]
     pipeline = Pipeline(model=mock_model, taskmodule=prepared_taskmodule, device=-1)
 
-    returned_document = pipeline(document, inplace=inplace, predict_field="entities")
+    returned_document = pipeline(document, inplace=inplace)
 
     if inplace:
         assert id(returned_document) == id(document)
@@ -108,7 +108,7 @@ def test_pipeline_with_document(documents, prepared_taskmodule, mock_model, inpl
 def test_pipeline_with_documents(documents, prepared_taskmodule, mock_model, inplace):
     pipeline = Pipeline(model=mock_model, taskmodule=prepared_taskmodule, device=-1)
 
-    returned_documents = pipeline(documents, inplace=inplace, predict_field="entities")
+    returned_documents = pipeline(documents, inplace=inplace)
 
     assert len(documents) == len(returned_documents)
 
@@ -135,9 +135,9 @@ def test_pipeline_with_dataset(dataset, prepared_taskmodule, mock_model, inplace
             InplaceNotSupportedException,
             match=re.escape("Datasets can't be modified in place. Please set inplace=False."),
         ):
-            returned_documents = pipeline(train_dataset, inplace=inplace, predict_field="entities")
+            returned_documents = pipeline(train_dataset, inplace=inplace)
     else:
-        returned_documents = pipeline(train_dataset, inplace=inplace, predict_field="entities")
+        returned_documents = pipeline(train_dataset, inplace=inplace)
 
         assert len(train_dataset) == len(returned_documents)
 


### PR DESCRIPTION
This removes the parameter `predict_field` from the pipeline since it is used only for clearing predictions beforehand which is not necessary in most of the use cases and should be done explicitly, if needed. Furthermore, its meaning is not clear for models that predict multiple fields at once, e.g. joint NER+RE models. It is also confusing for the user because its existence implies that it has any effect on the inner workings of the taskmodule / model.

Note: This PR adds instead the parameter `document_batch_size` to the pipeline which was missed in #218. 