### PR TITLE
prefix annotation id with an underscore

### DIFF
--- a/src/pytorch_ie/annotations.py
+++ b/src/pytorch_ie/annotations.py
@@ -114,7 +114,7 @@ class BinaryRelation(Annotation):
         _post_init_single_label(self)
 
     def asdict(self) -> Dict[str, Any]:
-        dct = super()._asdict(overrides={"head": self.head.id, "tail": self.tail.id})
+        dct = super()._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
         return dct
 
     @classmethod
@@ -144,7 +144,7 @@ class MultiLabeledBinaryRelation(Annotation):
 
     def asdict(self) -> Dict[str, Any]:
         # replace object references with object hashes
-        dct = super()._asdict(overrides={"head": self.head.id, "tail": self.tail.id})
+        dct = super()._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
         return dct
 
     @classmethod

--- a/src/pytorch_ie/annotations.py
+++ b/src/pytorch_ie/annotations.py
@@ -114,7 +114,7 @@ class BinaryRelation(Annotation):
         _post_init_single_label(self)
 
     def asdict(self) -> Dict[str, Any]:
-        dct = super()._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
+        dct = self._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
         return dct
 
     @classmethod
@@ -144,7 +144,7 @@ class MultiLabeledBinaryRelation(Annotation):
 
     def asdict(self) -> Dict[str, Any]:
         # replace object references with object hashes
-        dct = super()._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
+        dct = self._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
         return dct
 
     @classmethod

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -106,7 +106,7 @@ class Annotation:
         object.__setattr__(self, "_targets", value)
 
     @property
-    def id(self) -> int:
+    def _id(self) -> int:
         return hash(self)
 
     @property
@@ -153,7 +153,7 @@ class Annotation:
             value = _asdict_inner(field_value, dict)
             result.append((f.name, value))
         dct = dict(result)
-        dct["_id"] = self.id
+        dct["_id"] = self._id
         return dct
 
     def asdict(self) -> Dict[str, Any]:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -38,7 +38,7 @@ def test_label():
     assert label2.score == pytest.approx(0.5)
 
     assert label2.asdict() == {
-        "_id": label2.id,
+        "_id": label2._id,
         "label": "label2",
         "score": 0.5,
     }
@@ -56,7 +56,7 @@ def test_multilabel():
     assert multilabel2.score == pytest.approx((0.4, 0.5))
 
     assert multilabel2.asdict() == {
-        "_id": multilabel2.id,
+        "_id": multilabel2._id,
         "label": ("label3", "label4"),
         "score": (0.4, 0.5),
     }
@@ -75,7 +75,7 @@ def test_span():
     assert span.end == 2
 
     assert span.asdict() == {
-        "_id": span.id,
+        "_id": span._id,
         "start": 1,
         "end": 2,
     }
@@ -97,7 +97,7 @@ def test_labeled_span():
     assert labeled_span2.score == pytest.approx(0.5)
 
     assert labeled_span2.asdict() == {
-        "_id": labeled_span2.id,
+        "_id": labeled_span2._id,
         "start": 3,
         "end": 4,
         "label": "label2",
@@ -123,7 +123,7 @@ def test_multilabeled_span():
     assert multilabeled_span2.score == pytest.approx((0.4, 0.5))
 
     assert multilabeled_span2.asdict() == {
-        "_id": multilabeled_span2.id,
+        "_id": multilabeled_span2._id,
         "start": 3,
         "end": 4,
         "label": ("label3", "label4"),
@@ -154,7 +154,7 @@ def test_labeled_multi_span():
     assert labeled_multi_span2.score == pytest.approx(0.5)
 
     assert labeled_multi_span2.asdict() == {
-        "_id": labeled_multi_span2.id,
+        "_id": labeled_multi_span2._id,
         "slices": ((5, 6), (7, 8)),
         "label": "label2",
         "score": 0.5,
@@ -179,7 +179,7 @@ def test_multilabeled_multi_span():
     assert multilabeled_multi_span2.score == pytest.approx((0.4, 0.5))
 
     assert multilabeled_multi_span2.asdict() == {
-        "_id": multilabeled_multi_span2.id,
+        "_id": multilabeled_multi_span2._id,
         "slices": ((5, 6), (7, 8)),
         "label": ("label3", "label4"),
         "score": (0.4, 0.5),
@@ -212,16 +212,16 @@ def test_binary_relation():
     assert binary_relation2.score == pytest.approx(0.5)
 
     assert binary_relation2.asdict() == {
-        "_id": binary_relation2.id,
-        "head": head.id,
-        "tail": tail.id,
+        "_id": binary_relation2._id,
+        "head": head._id,
+        "tail": tail._id,
         "label": "label2",
         "score": 0.5,
     }
 
     annotation_store = {
-        head.id: head,
-        tail.id: tail,
+        head._id: head,
+        tail._id: tail,
     }
     _test_reconstruct(binary_relation2, annotation_store=annotation_store)
 
@@ -251,16 +251,16 @@ def test_multilabeled_binary_relation():
     assert binary_relation2.score == pytest.approx((0.4, 0.5))
 
     assert binary_relation2.asdict() == {
-        "_id": binary_relation2.id,
-        "head": head.id,
-        "tail": tail.id,
+        "_id": binary_relation2._id,
+        "head": head._id,
+        "tail": tail._id,
         "label": ("label3", "label4"),
         "score": (0.4, 0.5),
     }
 
     annotation_store = {
-        head.id: head,
-        tail.id: tail,
+        head._id: head,
+        tail._id: tail,
     }
     _test_reconstruct(binary_relation2, annotation_store=annotation_store)
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -90,8 +90,8 @@ def test_document_with_annotations():
     relation1 = BinaryRelation(head=labeled_span1, tail=labeled_span2, label="label1")
     relation2 = BinaryRelation(head=labeled_span1, tail=labeled_span2, label="label1")
     relation3 = BinaryRelation(head=labeled_span2, tail=labeled_span1, label="label1")
-    assert relation1.id == relation2.id
-    assert relation1.id != relation3.id
+    assert relation1._id == relation2._id
+    assert relation1._id != relation3._id
 
     document1.relations.append(relation1)
     assert len(document1.relations) == 1
@@ -152,10 +152,10 @@ def test_document_with_same_annotations():
     token1 = Span(start=start, end=end)
     token2 = Span(start=start, end=end)
     token3 = Span(start=start, end=end)
-    token0_id = token0.id
-    token1_id = token1.id
-    token2_id = token2.id
-    token3_id = token3.id
+    token0_id = token0._id
+    token1_id = token1._id
+    token2_id = token2._id
+    token3_id = token3._id
     # all spans are identical, so are there ids
     assert token1_id == token0_id
     assert token2_id == token0_id


### PR DESCRIPTION
This clarifies that the annotation id property is internal and allows the user to define its own "id" field.