### PR TITLE
[WIP] fix local data for PIE dataset loading scripts

### DIFF
--- a/src/pytorch_ie/data/builder.py
+++ b/src/pytorch_ie/data/builder.py
@@ -1,6 +1,6 @@
 import abc
 from functools import partial
-from typing import Any, Dict, Mapping, Optional, Type
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, Union
 
 from datasets.load import load_dataset_builder
 
@@ -22,6 +22,8 @@ class GeneratorBasedBuilder(datasets.builder.GeneratorBasedBuilder):
     # Define base builder kwargs. This should contain config names as keys and the respective
     # builder kwargs dicts as values.
     BASE_BUILDER_KWARGS_DICT: Optional[Dict[Optional[str], Dict[str, Any]]] = None
+    # These PIE dataset loading script arguments are also passed to the base builder.
+    BASE_BUILDER_COPY_ARGUMENTS: Union[List[str], Tuple[str]] = ("data_dir", "data_files")
 
     def __init__(self, base_dataset_kwargs: Optional[Dict[str, Any]] = None, **kwargs):
 
@@ -30,9 +32,9 @@ class GeneratorBasedBuilder(datasets.builder.GeneratorBasedBuilder):
             base_dataset_kwargs = base_dataset_kwargs or {}
             base_builder_kwargs: Dict[str, Any] = {}
 
-            for param_name in ["data_dir", "data_files"]:
-                if param_name in kwargs:
-                    base_builder_kwargs[param_name] = kwargs[param_name]
+            for argument_name in self.BASE_BUILDER_COPY_ARGUMENTS:
+                if argument_name in kwargs:
+                    base_builder_kwargs[argument_name] = kwargs[argument_name]
 
             config_name = kwargs.get("config_name", None)
 

--- a/src/pytorch_ie/data/builder.py
+++ b/src/pytorch_ie/data/builder.py
@@ -30,6 +30,10 @@ class GeneratorBasedBuilder(datasets.builder.GeneratorBasedBuilder):
             base_dataset_kwargs = base_dataset_kwargs or {}
             base_builder_kwargs: Dict[str, Any] = {}
 
+            for param_name in ["data_dir", "data_files"]:
+                if param_name in kwargs:
+                    base_builder_kwargs[param_name] = kwargs[param_name]
+
             config_name = kwargs.get("config_name", None)
 
             # get base config kwargs from mapping

--- a/src/pytorch_ie/data/builder.py
+++ b/src/pytorch_ie/data/builder.py
@@ -1,6 +1,6 @@
 import abc
 from functools import partial
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, Union
+from typing import Any, Dict, Iterable, Mapping, Optional, Type
 
 from datasets.load import load_dataset_builder
 
@@ -23,7 +23,7 @@ class GeneratorBasedBuilder(datasets.builder.GeneratorBasedBuilder):
     # builder kwargs dicts as values.
     BASE_BUILDER_KWARGS_DICT: Optional[Dict[Optional[str], Dict[str, Any]]] = None
     # These PIE dataset loading script arguments are also passed to the base builder.
-    BASE_BUILDER_COPY_ARGUMENTS: Union[List[str], Tuple[str]] = ("data_dir", "data_files")
+    BASE_BUILDER_COPY_ARGUMENTS: Iterable[str] = ("data_dir", "data_files")
 
     def __init__(self, base_dataset_kwargs: Optional[Dict[str, Any]] = None, **kwargs):
 


### PR DESCRIPTION
If a PIE dataset makes use of local data, e.g. via `datat_dir`, this parameter needs to be passed to the base dataset loader _and_ the pie dataset loader because only the `dl_manager` of the pie dataset loader is passed to the base loader which allows to access the data dir via `dl_manager.manual_dir`.

To fix this, this PR adds the following parameter to the `GeneratorBasedBuilder`:
```python
BASE_BUILDER_COPY_ARGUMENTS: Iterable[str] = ("data_dir", "data_files")
```

Thus, per default, the arguments `data_dir` and `data_files` are also passed to the base dataset loader mitigating the need to pass them to both data loaders (i.e. via `base_dataset_kwargs`).
