### PR TITLE
fix is_from_pretrained

### DIFF
--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -173,6 +173,9 @@ class PyTorchIEBaseModelHubMixin:
 
         config.update(model_kwargs)
 
+        # the entry may be already in the config, so we overwrite it
+        config["is_from_pretrained"] = True
+
         return cls._from_pretrained(
             model_id,
             revision,
@@ -182,7 +185,6 @@ class PyTorchIEBaseModelHubMixin:
             resume_download,
             local_files_only,
             use_auth_token,
-            is_from_pretrained=True,
             **config,
         )
 


### PR DESCRIPTION
When a fine-tuned model was loaded again for fine-tuning or evaluation, it clashed because the parameter `is_from_pretrained` was passed twice (loaded from the config and set as a parameter). With this PR, `is_from_pretrained` is not passed separately, but the config entry is just overwritten with `config["is_from_pretrained"] = True`.