### PR TITLE
improve RE taskmodule speed

### DIFF
--- a/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
@@ -194,6 +194,10 @@ class TransformerRETextClassificationTaskModule(_TransformerReTextClassification
             )
         self.tokenizer.add_tokens(list(self.argument_markers.values()), special_tokens=True)
 
+        self.argument_markers_to_id = {
+            marker: self.tokenizer.vocab[marker] for marker in self.argument_markers.values()
+        }
+
     def _config(self) -> Dict[str, Any]:
         config = super()._config()
         config["label_to_id"] = self.label_to_id
@@ -270,9 +274,6 @@ class TransformerRETextClassificationTaskModule(_TransformerReTextClassification
         assert (
             self.argument_markers is not None
         ), f"No argument markers available, was `prepare` already called?"
-        argument_markers_to_id = {
-            marker: self.tokenizer.vocab[marker] for marker in self.argument_markers.values()
-        }
 
         entities: Sequence[Span] = document[self.entity_annotation]
 
@@ -377,11 +378,11 @@ class TransformerRETextClassificationTaskModule(_TransformerReTextClassification
                 for entity, arg_name in zip(entity_pair, entity_args):
                     for pos in [START, END]:
                         if self.add_type_to_marker:
-                            markers[(arg_name, pos)] = argument_markers_to_id[
+                            markers[(arg_name, pos)] = self.argument_markers_to_id[
                                 self.argument_markers[(arg_name, pos, entity.label)]
                             ]
                         else:
-                            markers[(arg_name, pos)] = argument_markers_to_id[
+                            markers[(arg_name, pos)] = self.argument_markers_to_id[
                                 self.argument_markers[(arg_name, pos)]
                             ]
 

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -63,9 +63,9 @@ def model_output():
 
 def test_prepare(taskmodule_optional_marker, documents):
     taskmodule = taskmodule_optional_marker
-    assert not taskmodule.is_prepared()
+    assert not taskmodule.is_prepared
     taskmodule.prepare(documents)
-    assert taskmodule.is_prepared()
+    assert taskmodule.is_prepared
 
     if taskmodule.add_type_to_marker:
         assert taskmodule.entity_labels == ["ORG", "PER"]
@@ -349,7 +349,7 @@ def test_decode(prepared_taskmodule, documents, model_output, inplace):
 #     path = os.path.join(tmp_path, "taskmodule")
 #     prepared_taskmodule.save_pretrained(path)
 #     loaded_taskmodule = TransformerRETextClassificationTaskModule.from_pretrained(path)
-#     assert loaded_taskmodule.is_prepared()
+#     assert loaded_taskmodule.is_prepared
 #     assert loaded_taskmodule.argument_markers == prepared_taskmodule.argument_markers
 
 


### PR DESCRIPTION
* use method `_post_prepare()` that handles one-time initialization based on outcome of `_prepare()`, see #248 for further details.
* create `argument_markers_to_id` just once in `_post_prepare()` instead of in `encode()` which is called for each document

This significantly speeds up `encode()`. E.g. for KBP37 dataset:
```
[2023-02-13 14:03:14,547][__main__][INFO] - Starting training!                                                                                
encode inputs: 100%|██████████| 15807/15807 [00:02<00:00, 7299.08it/s]                                                                        
encode targets: 100%|██████████| 15807/15807 [00:00<00:00, 227466.26it/s]       
encode inputs: 100%|██████████| 1714/1714 [00:00<00:00, 7304.01it/s]                                                                          
encode targets: 100%|██████████| 1714/1714 [00:00<00:00, 169273.30it/s]                                                                       
encode inputs: 100%|██████████| 3379/3379 [00:00<00:00, 7603.22it/s]                                                                          
encode targets: 100%|██████████| 3379/3379 [00:00<00:00, 230583.00it/s]
```

Before this PR, it was 30-50 it/s for KBP37 or TACRED. Thanks @leonhardhennig for testing!