### PR TITLE
backwards compatible prepare() logic improvements

### DIFF
--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -433,4 +433,6 @@ class PyTorchIETaskmoduleModelHubMixin(PyTorchIEBaseModelHubMixin, Hyperparamete
         **module_kwargs,
     ):
         module_kwargs.pop("taskmodule_type")
-        return cls(**module_kwargs)
+        taskmodule = cls(**module_kwargs)
+        taskmodule._post_prepare()
+        return taskmodule

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -155,7 +155,7 @@ class TaskModule(
         TaskOutput,
     ],
 ):
-    ATTRIBUTES_REQUIRE_PREPARATION: List[str] = []
+    PREPARED_ATTRIBUTES: List[str] = []
 
     def __init__(self, encode_document_batch_size: Optional[int] = None, **kwargs):
         super().__init__(**kwargs)
@@ -164,23 +164,22 @@ class TaskModule(
     @property
     def is_prepared(self):
         """
-        Returns True, iff all attributes listed in ATTRIBUTES_REQUIRE_PREPARATION are set.
+        Returns True, iff all attributes listed in PREPARED_ATTRIBUTES are set.
         Note: Attributes set to None are not considered to be prepared!
         """
         return all(
-            getattr(self, attribute, None) is not None
-            for attribute in self.ATTRIBUTES_REQUIRE_PREPARATION
+            getattr(self, attribute, None) is not None for attribute in self.PREPARED_ATTRIBUTES
         )
 
     @property
     def prepared_attributes(self):
         if not self.is_prepared:
             raise Exception("The taskmodule is not prepared.")
-        return {param: getattr(self, param) for param in self.ATTRIBUTES_REQUIRE_PREPARATION}
+        return {param: getattr(self, param) for param in self.PREPARED_ATTRIBUTES}
 
     def _prepare(self, documents: Sequence[DocumentType]):
         """
-        This method needs to set all attributes listed in ATTRIBUTES_REQUIRE_PREPARATION.
+        This method needs to set all attributes listed in PREPARED_ATTRIBUTES.
         """
         pass
 
@@ -190,25 +189,27 @@ class TaskModule(
         """
         pass
 
+    def _assert_is_prepared(self, msg: Optional[str] = None):
+        if not self.is_prepared:
+            attributes_not_prepared = [
+                param for param in self.PREPARED_ATTRIBUTES if getattr(self, param, None) is None
+            ]
+            raise Exception(
+                f"{msg or ''} Required attributes that are not set: {str(attributes_not_prepared)}"
+            )
+
     def prepare(self, documents: Sequence[DocumentType]) -> None:
         if self.is_prepared:
-            if len(self.ATTRIBUTES_REQUIRE_PREPARATION) > 0:
+            if len(self.PREPARED_ATTRIBUTES) > 0:
                 msg = "The taskmodule is already prepared, do not prepare again."
                 for k, v in self.prepared_attributes.items():
                     msg += f"\n{k} = {str(v)}"
                 logger.warning(msg)
         else:
             self._prepare(documents)
-            if not self.is_prepared:
-                attributes_not_prepared = [
-                    param
-                    for param in self.ATTRIBUTES_REQUIRE_PREPARATION
-                    if getattr(self, param, None) is None
-                ]
-                raise Exception(
-                    f"_prepare() was called, but the taskmodule is not prepared. "
-                    f"Required attributes that are not set: {str(attributes_not_prepared)}"
-                )
+            self._assert_is_prepared(
+                msg="_prepare() was called, but the taskmodule is not prepared."
+            )
         self._post_prepare()
         return None
 

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -155,9 +155,40 @@ class TaskModule(
         TaskOutput,
     ],
 ):
+    ATTRIBUTES_REQUIRE_PREPARATION: List[str] = []
+
     def __init__(self, encode_document_batch_size: Optional[int] = None, **kwargs):
         super().__init__(**kwargs)
         self.encode_document_batch_size = encode_document_batch_size
+
+    @property
+    def is_prepared(self):
+        """
+        Returns True, iff all attributes listed in ATTRIBUTES_REQUIRE_PREPARATION are set.
+        Note: Attributes set to None are not considered to be prepared!
+        """
+        return all(
+            getattr(self, attribute, None) is not None
+            for attribute in self.ATTRIBUTES_REQUIRE_PREPARATION
+        )
+
+    @property
+    def prepared_attributes(self):
+        if not self.is_prepared:
+            raise Exception("The taskmodule is not prepared.")
+        return {param: getattr(self, param) for param in self.ATTRIBUTES_REQUIRE_PREPARATION}
+
+    def _prepare(self, documents: Sequence[DocumentType]):
+        """
+        This method needs to set all attributes listed in ATTRIBUTES_REQUIRE_PREPARATION.
+        """
+        pass
+
+    def _post_prepare(self):
+        """
+        Any code to do further one-time setup, but that requires the prepared attributes.
+        """
+        pass
 
     def _config(self) -> Dict[str, Any]:
         config = dict(self.hparams)

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -197,6 +197,8 @@ class TaskModule(
         config["taskmodule_type"] = (
             registered_name if registered_name is not None else this_class.__name__
         )
+        # add all prepared attributes
+        config.update(self.prepared_attributes)
         return config
 
     def prepare(self, documents: Sequence[DocumentType]) -> None:

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -213,10 +213,6 @@ class TaskModule(
         self._post_prepare()
         return None
 
-    def maybe_post_prepare(self):
-        if self.is_prepared:
-            self._post_prepare()
-
     def _config(self) -> Dict[str, Any]:
         config = dict(self.hparams)
         this_class = self.__class__

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -213,6 +213,10 @@ class TaskModule(
         self._post_prepare()
         return None
 
+    def maybe_post_prepare(self):
+        if self.is_prepared:
+            self._post_prepare()
+
     def _config(self) -> Dict[str, Any]:
         config = dict(self.hparams)
         this_class = self.__class__

--- a/src/pytorch_ie/taskmodules/simple_transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/simple_transformer_text_classification.py
@@ -89,8 +89,6 @@ class SimpleTransformerTextClassificationTaskModule(TaskModuleType):
         # this will be prepared from the data or loaded from the config
         self.label_to_id = label_to_id
 
-        self.maybe_post_prepare()
-
     def _prepare(self, documents: Sequence[DocumentType]) -> None:
         """
         Prepare the task module with training documents, e.g. collect all possible labels.

--- a/src/pytorch_ie/taskmodules/simple_transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/simple_transformer_text_classification.py
@@ -59,6 +59,10 @@ TaskModuleType = TaskModule[
 
 @TaskModule.register()
 class SimpleTransformerTextClassificationTaskModule(TaskModuleType):
+    # If these attributes are set, the taskmodule is considered as prepared. They should be calculated
+    # within _prepare() and are dumped automatically when saving the taskmodule with save_pretrained().
+    PREPARED_ATTRIBUTES = ["label_to_id"]
+
     def __init__(
         self,
         tokenizer_name_or_path: str,
@@ -83,44 +87,34 @@ class SimpleTransformerTextClassificationTaskModule(TaskModuleType):
         self.pad_to_multiple_of = pad_to_multiple_of
 
         # this will be prepared from the data or loaded from the config
-        self.label_to_id = label_to_id or {}
-        self.id_to_label = {v: k for k, v in self.label_to_id.items()}
+        self.label_to_id = label_to_id
 
-    def _config(self) -> Dict[str, Any]:
-        """
-        Add config entries. The config will be dumped when calling save_pretrained().
-        Entries of the config will be passed to the constructor of this taskmodule when
-        loading it with from_pretrained().
-        """
-        # add the label-to-id mapping to the config
-        config = super()._config()
-        config["label_to_id"] = self.label_to_id
-        return config
+        self.maybe_post_prepare()
 
-    def prepare(self, documents: Sequence[DocumentType]) -> None:
+    def _prepare(self, documents: Sequence[DocumentType]) -> None:
         """
         Prepare the task module with training documents, e.g. collect all possible labels.
+        This method needs to set all attributes listed in PREPARED_ATTRIBUTES.
         """
 
-        # Don't do anything if we directly created a prepared taskmodule. This may be useful for very large
-        # datasets where it is not reasonable to scan them before training.
-        if len(self.label_to_id) > 0:
-            logger.warning(
-                f"It looks like the taskmodule is already prepared since label_to_id contains entries, "
-                f"so they are not collected again. label_to_id = {str(self.label_to_id)}"
-            )
-        else:
-            # create the label-to-id mapping
-            labels = set()
-            for document in documents:
-                # all annotations of a document are hold in list like containers,
-                # so we have to take its first element
-                label_annotation = document.label[0]
-                labels.add(label_annotation.label)
+        # create the label-to-id mapping
+        labels = set()
+        for document in documents:
+            # all annotations of a document are hold in list like containers,
+            # so we have to take its first element
+            label_annotation = document.label[0]
+            labels.add(label_annotation.label)
 
-            # create the mapping, but spare the first index for the "O" (outside) class
-            self.label_to_id = {label: i + 1 for i, label in enumerate(sorted(labels))}
-            self.label_to_id["O"] = 0
+        # create the mapping, but spare the first index for the "O" (outside) class
+        self.label_to_id = {label: i + 1 for i, label in enumerate(sorted(labels))}
+        self.label_to_id["O"] = 0
+
+    def _post_prepare(self):
+        """
+        Any further preparation logic that requires the result of _prepare(). But its result is not serialized
+        with the taskmodule.
+        """
+
         self.id_to_label = {v: k for k, v in self.label_to_id.items()}
 
     def encode_input(
@@ -158,6 +152,7 @@ class SimpleTransformerTextClassificationTaskModule(TaskModuleType):
         # as above, all annotations are hold in lists, so we have to take its first element
         label_annotation = task_encoding.document.label[0]
         # translate the textual label to the target id
+        assert self.label_to_id is not None
         return self.label_to_id[label_annotation.label]
 
     def collate(self, task_encodings: Sequence[TaskEncodingType]) -> ModelEncodingType:


### PR DESCRIPTION
This is an alternative to #194, but much less invasive.

* implement:
  *  `PREPARED_ATTRIBUTES`: class attribute that defines what attributes need preparation
  * `is_prepared`: Returns True, iff all attributes listed in PREPARED_ATTRIBUTES are set. Note: Attributes set to None are not considered to be prepared!
  * `prepared_attributes`: Return all prepared attributes as dict.
  * `_prepare()`: This method should be overwritten in the respective taskmodule instead of `prepare()`. It needs to set all attributes listed in `PREPARED_ATTRIBUTES`.
  * `_post_prepare()`: This method can be overwritten in the respective taskmodule. It should contain any code to do further one-time setup, but that requires the prepared attributes. This is separated from `_prepare()` to allow to execute that code on a taskmodule loaded with `from_pretrained()` which is already prepared in the sense of `is_prepared` in that case, but may not be fully initialized. 
* Call `_post_prepare()` in the end of `Taskmodule.from_pretrained()`
* automatically add all `prepared_attributes` to the config
* modify logic of `prepare()`: it now calls `_prepare()` if the taskmodule is not yet prepared and calls `_post_prepare()` in the end (in any case)
* adjust `SimpleTransformerTextClassificationTaskModule` for these changes