### PR TITLE
use TypeAlias in all taskmodules

### DIFF
--- a/src/pytorch_ie/taskmodules/simple_transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/simple_transformer_text_classification.py
@@ -1,3 +1,12 @@
+"""
+workflow:
+    document
+        -> (input_encoding, target_encoding) -> task_encoding
+            -> model_encoding -> model_output
+        -> task_output
+    -> document
+"""
+
 import logging
 from typing import Any, Dict, Iterator, MutableMapping, Optional, Sequence, Tuple, TypedDict, Union
 
@@ -6,6 +15,7 @@ import torch
 from transformers import AutoTokenizer
 from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import TruncationStrategy
+from typing_extensions import TypeAlias
 
 from pytorch_ie.annotations import Label
 from pytorch_ie.core import AnnotationList, TaskEncoding, TaskModule, annotation_field
@@ -27,27 +37,17 @@ class TaskOutput(TypedDict, total=False):
     probability: float
 
 
-"""
-workflow:
-    document
-        -> (input_encoding, target_encoding) -> task_encoding
-            -> model_encoding -> model_output
-        -> task_output
-    -> document
-"""
-
-
 # Define task specific input and output types
-DocumentType = TextDocumentWithLabel
-InputEncodingType = MutableMapping[str, Any]
-TargetEncodingType = int
-ModelEncodingType = TransformerTextClassificationModelStepBatchEncoding
-ModelOutputType = TransformerTextClassificationModelBatchOutput
-TaskOutputType = TaskOutput
+DocumentType: TypeAlias = TextDocumentWithLabel
+InputEncodingType: TypeAlias = MutableMapping[str, Any]
+TargetEncodingType: TypeAlias = int
+ModelEncodingType: TypeAlias = TransformerTextClassificationModelStepBatchEncoding
+ModelOutputType: TypeAlias = TransformerTextClassificationModelBatchOutput
+TaskOutputType: TypeAlias = TaskOutput
 
 # This should be the same for all taskmodules
-TaskEncodingType = TaskEncoding[DocumentType, InputEncodingType, TargetEncodingType]
-TaskModuleType = TaskModule[
+TaskEncodingType: TypeAlias = TaskEncoding[DocumentType, InputEncodingType, TargetEncodingType]
+TaskModuleType: TypeAlias = TaskModule[
     DocumentType,
     InputEncodingType,
     TargetEncodingType,

--- a/src/pytorch_ie/taskmodules/transformer_seq2seq.py
+++ b/src/pytorch_ie/taskmodules/transformer_seq2seq.py
@@ -1,3 +1,12 @@
+"""
+workflow:
+    document
+        -> (input_encoding, target_encoding) -> task_encoding
+            -> model_encoding -> model_output
+        -> task_output
+    -> document
+"""
+
 import logging
 import re
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
@@ -5,6 +14,7 @@ from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 from transformers import AutoTokenizer
 from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import TruncationStrategy
+from typing_extensions import TypeAlias
 
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
 from pytorch_ie.core import Annotation, TaskEncoding, TaskModule
@@ -14,24 +24,15 @@ from pytorch_ie.models import (
     TransformerSeq2SeqModelStepBatchEncoding,
 )
 
-"""
-workflow:
-    Document
-        -> (InputEncoding, TargetEncoding) -> TaskEncoding -> TaskBatchEncoding
-            -> ModelBatchEncoding -> ModelBatchOutput
-        -> TaskOutput
-    -> Document
-"""
+TransformerSeq2SeqInputEncoding: TypeAlias = Dict[str, Sequence[int]]
+TransformerSeq2SeqTargetEncoding: TypeAlias = Dict[str, Sequence[int]]
 
-TransformerSeq2SeqInputEncoding = Dict[str, Sequence[int]]
-TransformerSeq2SeqTargetEncoding = Dict[str, Sequence[int]]
-
-TransformerSeq2SeqTaskEncoding = TaskEncoding[
+TransformerSeq2SeqTaskEncoding: TypeAlias = TaskEncoding[
     TextDocument, TransformerSeq2SeqInputEncoding, TransformerSeq2SeqTargetEncoding
 ]
-TransformerSeq2SeqTaskOutput = Sequence[Dict[str, Any]]
+TransformerSeq2SeqTaskOutput: TypeAlias = Sequence[Dict[str, Any]]
 
-_TransformerSeq2SeqTaskModule = TaskModule[
+_TransformerSeq2SeqTaskModule: TypeAlias = TaskModule[
     # _InputEncoding, _TargetEncoding, _TaskBatchEncoding, _ModelBatchOutput, _TaskOutput
     TextDocument,
     TransformerSeq2SeqInputEncoding,

--- a/src/pytorch_ie/taskmodules/transformer_span_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_span_classification.py
@@ -1,3 +1,12 @@
+"""
+workflow:
+    document
+        -> (input_encoding, target_encoding) -> task_encoding
+            -> model_encoding -> model_output
+        -> task_output
+    -> document
+"""
+
 import logging
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union
 
@@ -7,6 +16,7 @@ import torch.nn.functional as F
 from transformers import AutoTokenizer
 from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import BatchEncoding, TruncationStrategy
+from typing_extensions import TypeAlias
 
 from pytorch_ie.annotations import LabeledSpan, MultiLabeledSpan, Span
 from pytorch_ie.core import TaskEncoding, TaskModule
@@ -16,26 +26,17 @@ from pytorch_ie.models.transformer_span_classification import (
     TransformerSpanClassificationModelStepBatchEncoding,
 )
 
-"""
-workflow:
-    Document
-        -> (InputEncoding, TargetEncoding) -> TaskEncoding -> TaskBatchEncoding
-            -> ModelBatchEncoding -> ModelBatchOutput
-        -> TaskOutput
-    -> Document
-"""
+TransformerSpanClassificationInputEncoding: TypeAlias = BatchEncoding
+TransformerSpanClassificationTargetEncoding: TypeAlias = Sequence[Tuple[int, int, int]]
 
-TransformerSpanClassificationInputEncoding = BatchEncoding
-TransformerSpanClassificationTargetEncoding = Sequence[Tuple[int, int, int]]
-
-TransformerSpanClassificationTaskEncoding = TaskEncoding[
+TransformerSpanClassificationTaskEncoding: TypeAlias = TaskEncoding[
     TextDocument,
     TransformerSpanClassificationInputEncoding,
     TransformerSpanClassificationTargetEncoding,
 ]
-TransformerSpanClassificationTaskOutput = Dict[str, Any]
+TransformerSpanClassificationTaskOutput: TypeAlias = Dict[str, Any]
 
-_TransformerSpanClassificationTaskModule = TaskModule[
+_TransformerSpanClassificationTaskModule: TypeAlias = TaskModule[
     # _InputEncoding, _TargetEncoding, _TaskBatchEncoding, _ModelBatchOutput, _TaskOutput
     TextDocument,
     TransformerSpanClassificationInputEncoding,

--- a/src/pytorch_ie/taskmodules/transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_text_classification.py
@@ -1,3 +1,12 @@
+"""
+workflow:
+    document
+        -> (input_encoding, target_encoding) -> task_encoding
+            -> model_encoding -> model_output
+        -> task_output
+    -> document
+"""
+
 from typing import (
     Any,
     Dict,
@@ -16,6 +25,7 @@ import torch
 from transformers import AutoTokenizer
 from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import TruncationStrategy
+from typing_extensions import TypeAlias
 
 from pytorch_ie.annotations import Label, MultiLabel
 from pytorch_ie.core import TaskEncoding, TaskModule
@@ -25,19 +35,10 @@ from pytorch_ie.models.transformer_text_classification import (
     TransformerTextClassificationModelStepBatchEncoding,
 )
 
-"""
-workflow:
-    Document
-        -> (InputEncoding, TargetEncoding) -> TaskEncoding -> TaskBatchEncoding
-            -> ModelBatchEncoding -> ModelBatchOutput
-        -> TaskOutput
-    -> Document
-"""
+TransformerTextClassificationInputEncoding: TypeAlias = MutableMapping[str, Any]
+TransformerTextClassificationTargetEncoding: TypeAlias = Sequence[int]
 
-TransformerTextClassificationInputEncoding = MutableMapping[str, Any]
-TransformerTextClassificationTargetEncoding = Sequence[int]
-
-TransformerTextClassificationTaskEncoding = TaskEncoding[
+TransformerTextClassificationTaskEncoding: TypeAlias = TaskEncoding[
     TextDocument,
     TransformerTextClassificationInputEncoding,
     TransformerTextClassificationTargetEncoding,
@@ -54,12 +55,12 @@ class TransformerTextClassificationTaskOutputMulti(TypedDict, total=False):
     probabilities: Sequence[Sequence[float]]
 
 
-TransformerTextClassificationTaskOutput = Union[
+TransformerTextClassificationTaskOutput: TypeAlias = Union[
     TransformerTextClassificationTaskOutputSingle,
     TransformerTextClassificationTaskOutputMulti,
 ]
 
-_TransformerTextClassificationTaskModule = TaskModule[
+_TransformerTextClassificationTaskModule: TypeAlias = TaskModule[
     # _InputEncoding, _TargetEncoding, _TaskBatchEncoding, _ModelBatchOutput, _TaskOutput
     TextDocument,
     TransformerTextClassificationInputEncoding,

--- a/src/pytorch_ie/taskmodules/transformer_token_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_token_classification.py
@@ -1,3 +1,12 @@
+"""
+workflow:
+    Document
+        -> (InputEncoding, TargetEncoding) -> TaskEncoding -> TaskBatchEncoding
+            -> ModelBatchEncoding -> ModelBatchOutput
+        -> TaskOutput
+    -> Document
+"""
+
 import copy
 import logging
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
@@ -7,6 +16,7 @@ import torch.nn.functional as F
 from transformers import AutoTokenizer
 from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import BatchEncoding, TruncationStrategy
+from typing_extensions import TypeAlias
 
 from pytorch_ie.annotations import LabeledSpan, Span
 from pytorch_ie.core import TaskEncoding, TaskModule
@@ -24,25 +34,17 @@ from pytorch_ie.utils.span import (
 )
 from pytorch_ie.utils.window import enumerate_windows
 
-"""
-workflow:
-    Document
-        -> (InputEncoding, TargetEncoding) -> TaskEncoding -> TaskBatchEncoding
-            -> ModelBatchEncoding -> ModelBatchOutput
-        -> TaskOutput
-    -> Document
-"""
-TransformerTokenClassificationInputEncoding = Union[Dict[str, Any], BatchEncoding]
-TransformerTokenClassificationTargetEncoding = Sequence[int]
+TransformerTokenClassificationInputEncoding: TypeAlias = Union[Dict[str, Any], BatchEncoding]
+TransformerTokenClassificationTargetEncoding: TypeAlias = Sequence[int]
 
-TransformerTokenClassificationTaskEncoding = TaskEncoding[
+TransformerTokenClassificationTaskEncoding: TypeAlias = TaskEncoding[
     TextDocument,
     TransformerTokenClassificationInputEncoding,
     TransformerTokenClassificationTargetEncoding,
 ]
-TransformerTokenClassificationTaskOutput = Dict[str, Any]
+TransformerTokenClassificationTaskOutput: TypeAlias = Dict[str, Any]
 
-_TransformerTokenClassificationTaskModule = TaskModule[
+_TransformerTokenClassificationTaskModule: TypeAlias = TaskModule[
     # _InputEncoding, _TargetEncoding, _TaskBatchEncoding, _ModelBatchOutput, _TaskOutput
     TextDocument,
     TransformerTokenClassificationInputEncoding,


### PR DESCRIPTION
See #254. This also moves the docstrings to the beginning of the files.