### PR TITLE
simplify hf_hub_mixin

### DIFF
--- a/src/pytorch_ie/auto.py
+++ b/src/pytorch_ie/auto.py
@@ -24,7 +24,7 @@ class AutoTaskModule(PyTorchIETaskmoduleModelHubMixin):
         use_auth_token,
         **module_kwargs,
     ) -> TaskModule:
-        class_name = module_kwargs.pop(cls.type_key)
+        class_name = module_kwargs.pop(cls.config_type_key)
         clazz = TaskModule.by_name(class_name)  # type: ignore
         return clazz(**module_kwargs)
 
@@ -66,7 +66,7 @@ class AutoModel(PyTorchIEModelHubMixin):
                 local_files_only=local_files_only,
             )
 
-        class_name = model_kwargs.pop(cls.type_key)
+        class_name = model_kwargs.pop(cls.config_type_key)
         clazz = PyTorchIEModel.by_name(class_name)
         model = clazz(**model_kwargs)
 

--- a/src/pytorch_ie/auto.py
+++ b/src/pytorch_ie/auto.py
@@ -24,7 +24,7 @@ class AutoTaskModule(PyTorchIETaskmoduleModelHubMixin):
         use_auth_token,
         **module_kwargs,
     ) -> TaskModule:
-        class_name = module_kwargs.pop("taskmodule_type")
+        class_name = module_kwargs.pop(cls.type_key)
         clazz = TaskModule.by_name(class_name)  # type: ignore
         return clazz(**module_kwargs)
 
@@ -66,7 +66,7 @@ class AutoModel(PyTorchIEModelHubMixin):
                 local_files_only=local_files_only,
             )
 
-        class_name = model_kwargs.pop("model_type")
+        class_name = model_kwargs.pop(cls.type_key)
         clazz = PyTorchIEModel.by_name(class_name)
         model = clazz(**model_kwargs)
 

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -379,8 +379,8 @@ class PyTorchIEModelHubMixin(PyTorchIEBaseModelHubMixin):
                 use_auth_token=use_auth_token,
                 local_files_only=local_files_only,
             )
-        if cls.type_key is not None:
-            model_kwargs.pop(cls.type_key)
+        if cls.config_type_key is not None:
+            model_kwargs.pop(cls.config_type_key)
         model = cls(**model_kwargs)
 
         state_dict = torch.load(model_file, map_location=map_location)

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -308,6 +308,7 @@ class PyTorchIEBaseModelHubMixin:
 
 
 class PyTorchIEModelHubMixin(PyTorchIEBaseModelHubMixin):
+    config_name = MODEL_CONFIG_NAME
     config_type_key = MODEL_CONFIG_TYPE_KEY
 
     def __init__(self, *args, **kwargs):

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -11,7 +11,6 @@ from huggingface_hub.constants import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
 from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import HfApi, HfFolder
 from huggingface_hub.repository import Repository
-from pytorch_lightning.core.mixins import HyperparametersMixin
 
 logger = logging.getLogger(__name__)
 
@@ -383,7 +382,7 @@ class PyTorchIEModelHubMixin(PyTorchIEBaseModelHubMixin):
         return model
 
 
-class PyTorchIETaskmoduleModelHubMixin(PyTorchIEBaseModelHubMixin, HyperparametersMixin):
+class PyTorchIETaskmoduleModelHubMixin(PyTorchIEBaseModelHubMixin):
     config_name = TASKMODULE_CONFIG_NAME
 
     def __init__(self, *args, **kwargs):
@@ -410,11 +409,6 @@ class PyTorchIETaskmoduleModelHubMixin(PyTorchIEBaseModelHubMixin, Hyperparamete
             >>> model = MyModel.from_pretrained("username/mymodel@main")
         """
         super().__init__(*args, **kwargs)
-
-    def _config(self) -> Dict[str, Any]:
-        config = dict(self.hparams)
-        config["taskmodule_type"] = self.__class__.__name__
-        return config
 
     def _save_pretrained(self, save_directory):
         return None

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -304,6 +304,8 @@ class PyTorchIEBaseModelHubMixin:
 
 
 class PyTorchIEModelHubMixin(PyTorchIEBaseModelHubMixin):
+    type_key = "model_type"
+
     def __init__(self, *args, **kwargs):
         """
         Mix this class with your torch-model class for ease process of saving & loading from huggingface-hub
@@ -372,7 +374,8 @@ class PyTorchIEModelHubMixin(PyTorchIEBaseModelHubMixin):
                 use_auth_token=use_auth_token,
                 local_files_only=local_files_only,
             )
-        model_kwargs.pop("model_type")
+        if cls.type_key is not None:
+            model_kwargs.pop(cls.type_key)
         model = cls(**model_kwargs)
 
         state_dict = torch.load(model_file, map_location=map_location)
@@ -384,6 +387,7 @@ class PyTorchIEModelHubMixin(PyTorchIEBaseModelHubMixin):
 
 class PyTorchIETaskmoduleModelHubMixin(PyTorchIEBaseModelHubMixin):
     config_name = TASKMODULE_CONFIG_NAME
+    type_key = "taskmodule_type"
 
     def __init__(self, *args, **kwargs):
         """
@@ -426,6 +430,7 @@ class PyTorchIETaskmoduleModelHubMixin(PyTorchIEBaseModelHubMixin):
         use_auth_token,
         **module_kwargs,
     ):
-        module_kwargs.pop("taskmodule_type")
+        if cls.type_key is not None:
+            module_kwargs.pop(cls.type_key)
         taskmodule = cls(**module_kwargs)
         return taskmodule

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -428,5 +428,4 @@ class PyTorchIETaskmoduleModelHubMixin(PyTorchIEBaseModelHubMixin):
     ):
         module_kwargs.pop("taskmodule_type")
         taskmodule = cls(**module_kwargs)
-        taskmodule._post_prepare()
         return taskmodule

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -14,7 +14,10 @@ from huggingface_hub.repository import Repository
 
 logger = logging.getLogger(__name__)
 
+MODEL_CONFIG_NAME = CONFIG_NAME
 TASKMODULE_CONFIG_NAME = "taskmodule_config.json"
+MODEL_CONFIG_TYPE_KEY = "model_type"
+TASKMODULE_CONFIG_TYPE_KEY = "taskmodule_type"
 
 
 class PyTorchIEBaseModelHubMixin:
@@ -24,7 +27,8 @@ class PyTorchIEBaseModelHubMixin:
     your classes. See ``huggingface_hub.PyTorchModelHubMixin`` for an example.
     """
 
-    config_name = CONFIG_NAME
+    config_name = MODEL_CONFIG_NAME
+    config_type_key = MODEL_CONFIG_TYPE_KEY
 
     def __init__(self, *args, is_from_pretrained: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
@@ -304,7 +308,7 @@ class PyTorchIEBaseModelHubMixin:
 
 
 class PyTorchIEModelHubMixin(PyTorchIEBaseModelHubMixin):
-    type_key = "model_type"
+    config_type_key = MODEL_CONFIG_TYPE_KEY
 
     def __init__(self, *args, **kwargs):
         """
@@ -387,7 +391,7 @@ class PyTorchIEModelHubMixin(PyTorchIEBaseModelHubMixin):
 
 class PyTorchIETaskmoduleModelHubMixin(PyTorchIEBaseModelHubMixin):
     config_name = TASKMODULE_CONFIG_NAME
-    type_key = "taskmodule_type"
+    config_type_key = TASKMODULE_CONFIG_TYPE_KEY
 
     def __init__(self, *args, **kwargs):
         """
@@ -430,7 +434,7 @@ class PyTorchIETaskmoduleModelHubMixin(PyTorchIEBaseModelHubMixin):
         use_auth_token,
         **module_kwargs,
     ):
-        if cls.type_key is not None:
-            module_kwargs.pop(cls.type_key)
+        if cls.config_type_key is not None:
+            module_kwargs.pop(cls.config_type_key)
         taskmodule = cls(**module_kwargs)
         return taskmodule

--- a/src/pytorch_ie/core/model.py
+++ b/src/pytorch_ie/core/model.py
@@ -9,7 +9,7 @@ from pytorch_ie.core.registrable import Registrable
 class PyTorchIEModel(PyTorchIEModelHubMixin, LightningModule, Registrable):
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}
-        config["model_type"] = PyTorchIEModel.name_for_object_class(self)
+        config[self.type_key] = PyTorchIEModel.name_for_object_class(self)
         # add all hparams
         config.update(self.hparams)
         return config

--- a/src/pytorch_ie/core/model.py
+++ b/src/pytorch_ie/core/model.py
@@ -9,7 +9,7 @@ from pytorch_ie.core.registrable import Registrable
 class PyTorchIEModel(PyTorchIEModelHubMixin, LightningModule, Registrable):
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}
-        config[self.type_key] = PyTorchIEModel.name_for_object_class(self)
+        config[self.config_type_key] = PyTorchIEModel.name_for_object_class(self)
         # add all hparams
         config.update(self.hparams)
         return config

--- a/src/pytorch_ie/core/model.py
+++ b/src/pytorch_ie/core/model.py
@@ -8,12 +8,10 @@ from pytorch_ie.core.registrable import Registrable
 
 class PyTorchIEModel(PyTorchIEModelHubMixin, LightningModule, Registrable):
     def _config(self) -> Dict[str, Any]:
-        config = dict(self.hparams)
-        this_class = self.__class__
-        registered_name = PyTorchIEModel.registered_name_for_class(this_class)
-        config["model_type"] = (
-            registered_name if registered_name is not None else this_class.__name__
-        )
+        config = super()._config() or {}
+        config["model_type"] = PyTorchIEModel.name_for_object_class(self)
+        # add all hparams
+        config.update(self.hparams)
         return config
 
     def predict(

--- a/src/pytorch_ie/core/registrable.py
+++ b/src/pytorch_ie/core/registrable.py
@@ -51,3 +51,9 @@ class Registrable:
     def registered_name_for_class(cls: Type[T], clazz: Type[T]) -> Optional[str]:
         inverse_lookup = {v: k for k, v in Registrable._registry[cls].items()}
         return inverse_lookup.get(clazz)
+
+    @classmethod
+    def name_for_object_class(cls: Type[T], obj: T) -> str:
+        obj_class = obj.__class__
+        registered_name = cls.registered_name_for_class(obj_class)
+        return registered_name if registered_name is not None else obj_class.__name__

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -217,7 +217,7 @@ class TaskModule(
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config() or {}
-        config["taskmodule_type"] = TaskModule.name_for_object_class(self)
+        config[self.config_type_key] = TaskModule.name_for_object_class(self)
         # add all hparams
         config.update(self.hparams)
         # add all prepared attributes

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -224,6 +224,16 @@ class TaskModule(
         config.update(self.prepared_attributes)
         return config
 
+    @classmethod
+    def _from_pretrained(
+        cls,
+        *args,
+        **kwargs,
+    ):
+        taskmodule = super()._from_pretrained(*args, **kwargs)
+        taskmodule._post_prepare()
+        return taskmodule
+
     def batch_encode(
         self,
         documents: Union[Sequence[DocumentType], Dataset],

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import torch.utils.data.dataset as torch_dataset
+from pytorch_lightning.core.mixins import HyperparametersMixin
 from tqdm import tqdm
 
 from pytorch_ie.core.document import Annotation, Document
@@ -145,6 +146,7 @@ class TaskEncodingSequence(
 class TaskModule(
     ABC,
     PyTorchIETaskmoduleModelHubMixin,
+    HyperparametersMixin,
     Registrable,
     Generic[
         DocumentType,
@@ -214,12 +216,10 @@ class TaskModule(
         return None
 
     def _config(self) -> Dict[str, Any]:
-        config = dict(self.hparams)
-        this_class = self.__class__
-        registered_name = TaskModule.registered_name_for_class(this_class)
-        config["taskmodule_type"] = (
-            registered_name if registered_name is not None else this_class.__name__
-        )
+        config = super()._config() or {}
+        config["taskmodule_type"] = TaskModule.name_for_object_class(self)
+        # add all hparams
+        config.update(self.hparams)
         # add all prepared attributes
         config.update(self.prepared_attributes)
         return config

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -42,6 +42,8 @@ def test_auto_taskmodule_full_cycle_with_name(tmp_path):
     taskmodule = MyTransformerSpanClassificationTaskModule(
         tokenizer_name_or_path="bert-base-uncased"
     )
+    config = taskmodule._config()
+    assert config["taskmodule_type"] == "mytaskmodule"
     taskmodule.prepare([])
     taskmodule.save_pretrained(save_directory=str(tmp_path))
 


### PR DESCRIPTION
Mainly, this does:
* do not let `PyTorchIETaskmoduleModelHubMixin` inherit from `HyperparametersMixin`, this is handled one level above, i.e. in `PyTorchIEModel`, to separate concerns
* overwrite `_from_pretrained()` in `TaskModule` to call `_post_prepare()` where that is defined (previously, this was done in `PyTorchIETaskmoduleModelHubMixin._from_pretrained()` where `_post_prepare()` may not be available)

In addition, some quality of life changes:
* add class attribute `config_type_key` to `PyTorchIEBaseModelHubMixin`
* add constants `MODEL_CONFIG_NAME`, `TASKMODULE_CONFIG_NAME`, `MODEL_CONFIG_TYPE_KEY`, and `TASKMODULE_CONFIG_TYPE_KEY`
* add helper class `Registrable.name_for_object_class(cls: Type[T], obj: T) -> str` to retrieve the name given an object