### PR TITLE
Improvements for annotations with references

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,42 +195,6 @@ As usual for dataclasses, annotations can be converted to json like objects with
 also created with `MyAnnotation.fromdict(dct, annotation_store)`. Both methods are required because documents and
 their annotations are created on the fly when working with PIE datasets (see below).
 
-Sometimes, it is required to overwrite both methods. This is the case when targeting another annotation field. Consider
-the following example where `head` and `tail` are entries from another annotation field:
-
-```python
-@dataclass(eq=True, frozen=True)
-class BinaryRelation(Annotation):
-    head: Span
-    tail: Span
-    label: str
-
-    def asdict(self) -> Dict[str, Any]:
-        # Convert the annotations to their ids.
-        # We use the _asdicts() method with overrides to avoid converting the original
-        # entries to dicts in the first place (this can slow down the preprocessing a lot).
-        dct = self._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
-        return dct
-
-    @classmethod
-    def fromdict(
-        cls,
-        dct: Dict[str, Any],
-        annotation_store: Optional[Dict[int, Annotation]] = None,
-    ):
-        # copy to not modify the input
-        tmp_dct = dict(dct)
-        # get the annotations by their ids
-        tmp_dct["head"] = resolve_annotation(tmp_dct["head"], store=annotation_store)
-        tmp_dct["tail"] = resolve_annotation(tmp_dct["tail"], store=annotation_store)
-        return super().fromdict(tmp_dct, annotation_store)
-```
-
-Here it is necessary to replace the referenced `Span` annotations with their ids during serialization because
-we save them already in the respective annotation field. Thus, we also have to replace the ids with the actual
-annotations during construction. This can be easily done with the helper method
-`resolve_annotation(id_or_annotation, store)`.
-
 </details>
 </details>
 <details>

--- a/src/pytorch_ie/annotations.py
+++ b/src/pytorch_ie/annotations.py
@@ -113,21 +113,21 @@ class BinaryRelation(Annotation):
     def __post_init__(self) -> None:
         _post_init_single_label(self)
 
-    def asdict(self) -> Dict[str, Any]:
-        dct = self._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
-        return dct
+    # def asdict(self) -> Dict[str, Any]:
+    #    dct = self._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
+    #    return dct
 
-    @classmethod
-    def fromdict(
-        cls,
-        dct: Dict[str, Any],
-        annotation_store: Optional[Dict[int, Annotation]] = None,
-    ):
-        # copy to not modify the input
-        tmp_dct = dict(dct)
-        tmp_dct["head"] = resolve_annotation(tmp_dct["head"], store=annotation_store)
-        tmp_dct["tail"] = resolve_annotation(tmp_dct["tail"], store=annotation_store)
-        return super().fromdict(tmp_dct, annotation_store)
+    # @classmethod
+    # def fromdict(
+    #    cls,
+    #    dct: Dict[str, Any],
+    #    annotation_store: Optional[Dict[int, Annotation]] = None,
+    # ):
+    #    # copy to not modify the input
+    #    tmp_dct = dict(dct)
+    #    tmp_dct["head"] = resolve_annotation(tmp_dct["head"], store=annotation_store)
+    #    tmp_dct["tail"] = resolve_annotation(tmp_dct["tail"], store=annotation_store)
+    #    return super().fromdict(tmp_dct, annotation_store)
 
 
 @dataclass(eq=True, frozen=True)
@@ -140,21 +140,21 @@ class MultiLabeledBinaryRelation(Annotation):
     def __post_init__(self) -> None:
         _post_init_multi_label(self)
 
-    def asdict(self) -> Dict[str, Any]:
-        # replace object references with object hashes
-        dct = self._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
-        return dct
+    # def asdict(self) -> Dict[str, Any]:
+    #    # replace object references with object hashes
+    #    dct = self._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
+    #    return dct
 
-    @classmethod
-    def fromdict(
-        cls,
-        dct: Dict[str, Any],
-        annotation_store: Optional[Dict[int, "Annotation"]] = None,
-    ):
-        tmp_dct = dict(dct)
-        tmp_dct.pop("_id", None)
-
-        tmp_dct["head"] = resolve_annotation(tmp_dct["head"], store=annotation_store)
-        tmp_dct["tail"] = resolve_annotation(tmp_dct["tail"], store=annotation_store)
-
-        return cls(**tmp_dct)
+    # @classmethod
+    # def fromdict(
+    #    cls,
+    #    dct: Dict[str, Any],
+    #    annotation_store: Optional[Dict[int, "Annotation"]] = None,
+    # ):
+    #    tmp_dct = dict(dct)
+    #    tmp_dct.pop("_id", None)
+    #
+    #    tmp_dct["head"] = resolve_annotation(tmp_dct["head"], store=annotation_store)
+    #    tmp_dct["tail"] = resolve_annotation(tmp_dct["tail"], store=annotation_store)
+    #
+    #    return cls(**tmp_dct)

--- a/src/pytorch_ie/annotations.py
+++ b/src/pytorch_ie/annotations.py
@@ -123,3 +123,27 @@ class MultiLabeledBinaryRelation(Annotation):
 
     def __post_init__(self) -> None:
         _post_init_multi_label(self)
+
+
+@dataclass(eq=True, frozen=True)
+class BinaryRelationWithOptionalTrigger(Annotation):
+    head: Span
+    tail: Span
+    label: str
+    trigger: Optional[Span] = None
+    score: float = 1.0
+
+    def __post_init__(self) -> None:
+        _post_init_single_label(self)
+
+
+@dataclass(eq=True, frozen=True)
+class BinaryRelationWithEvidence(Annotation):
+    head: Span
+    tail: Span
+    label: str
+    evidence: Tuple[Span, ...]
+    score: float = 1.0
+
+    def __post_init__(self) -> None:
+        _post_init_single_label(self)

--- a/src/pytorch_ie/annotations.py
+++ b/src/pytorch_ie/annotations.py
@@ -123,27 +123,3 @@ class MultiLabeledBinaryRelation(Annotation):
 
     def __post_init__(self) -> None:
         _post_init_multi_label(self)
-
-
-@dataclass(eq=True, frozen=True)
-class BinaryRelationWithOptionalTrigger(Annotation):
-    head: Span
-    tail: Span
-    label: str
-    trigger: Optional[Span] = None
-    score: float = 1.0
-
-    def __post_init__(self) -> None:
-        _post_init_single_label(self)
-
-
-@dataclass(eq=True, frozen=True)
-class BinaryRelationWithEvidence(Annotation):
-    head: Span
-    tail: Span
-    label: str
-    evidence: Tuple[Span, ...]
-    score: float = 1.0
-
-    def __post_init__(self) -> None:
-        _post_init_single_label(self)

--- a/src/pytorch_ie/annotations.py
+++ b/src/pytorch_ie/annotations.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple
+from typing import Optional, Tuple
 
-from pytorch_ie.core.document import Annotation, resolve_annotation
+from pytorch_ie.core.document import Annotation
 
 
 def _post_init_single_label(self):
@@ -113,22 +113,6 @@ class BinaryRelation(Annotation):
     def __post_init__(self) -> None:
         _post_init_single_label(self)
 
-    # def asdict(self) -> Dict[str, Any]:
-    #    dct = self._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
-    #    return dct
-
-    # @classmethod
-    # def fromdict(
-    #    cls,
-    #    dct: Dict[str, Any],
-    #    annotation_store: Optional[Dict[int, Annotation]] = None,
-    # ):
-    #    # copy to not modify the input
-    #    tmp_dct = dict(dct)
-    #    tmp_dct["head"] = resolve_annotation(tmp_dct["head"], store=annotation_store)
-    #    tmp_dct["tail"] = resolve_annotation(tmp_dct["tail"], store=annotation_store)
-    #    return super().fromdict(tmp_dct, annotation_store)
-
 
 @dataclass(eq=True, frozen=True)
 class MultiLabeledBinaryRelation(Annotation):
@@ -139,22 +123,3 @@ class MultiLabeledBinaryRelation(Annotation):
 
     def __post_init__(self) -> None:
         _post_init_multi_label(self)
-
-    # def asdict(self) -> Dict[str, Any]:
-    #    # replace object references with object hashes
-    #    dct = self._asdict(overrides={"head": self.head._id, "tail": self.tail._id})
-    #    return dct
-
-    # @classmethod
-    # def fromdict(
-    #    cls,
-    #    dct: Dict[str, Any],
-    #    annotation_store: Optional[Dict[int, "Annotation"]] = None,
-    # ):
-    #    tmp_dct = dict(dct)
-    #    tmp_dct.pop("_id", None)
-    #
-    #    tmp_dct["head"] = resolve_annotation(tmp_dct["head"], store=annotation_store)
-    #    tmp_dct["tail"] = resolve_annotation(tmp_dct["tail"], store=annotation_store)
-    #
-    #    return cls(**tmp_dct)

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -77,10 +77,10 @@ def _is_tuple_of_annotations(t: Any) -> bool:
 
 
 def _get_reference_fields_and_container_types(
-    cls: typing.Type,
+    annotation_class: typing.Type["Annotation"],
 ) -> Dict[str, Optional[typing.Type]]:
     containers: Dict[str, Optional[typing.Type]] = {}
-    for field in dataclasses.fields(cls):
+    for field in dataclasses.fields(annotation_class):
         if field.name == "_targets":
             continue
         if not _contains_annotation_type(field.type):
@@ -95,7 +95,7 @@ def _get_reference_fields_and_container_types(
         if _is_tuple_of_annotations(field_type):
             containers[field.name] = tuple
             continue
-        annot_name = cls.__name__
+        annot_name = annotation_class.__name__
         raise TypeError(
             f"The type '{field.type}' of the field '{field.name}' from Annotation subclass '{annot_name}' can not "
             f"be handled automatically. For automatic handling, type constructs that contain any Annotation subclasses "

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -71,7 +71,7 @@ def _get_annotation_fields_with_container(cls: typing.Type) -> Dict[str, Any]:
         if is_annotation_subclass(field_type):
             containers[field.name] = None
         type_args = typing.get_args(field_type)
-        if typing.get_origin(field_type) == tuple and issubclass(type_args[0], Annotation):
+        if typing.get_origin(field_type) == tuple and is_annotation_subclass(type_args[0]):
             if not (
                 type_args[1] == Ellipsis
                 or [issubclass(type_arg, Annotation) for type_arg in type_args]

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -76,7 +76,9 @@ def _is_tuple_of_annotations(t: Any) -> bool:
         return False
 
 
-def _get_annotation_fields_with_container(cls: typing.Type) -> Dict[str, Optional[typing.Type]]:
+def _get_reference_fields_and_container_types(
+    cls: typing.Type,
+) -> Dict[str, Optional[typing.Type]]:
     containers: Dict[str, Optional[typing.Type]] = {}
     for field in dataclasses.fields(cls):
         if field.name == "_targets":
@@ -218,8 +220,10 @@ class Annotation:
 
     def asdict(self) -> Dict[str, Any]:
         overrides = {}
-        annotation_fields_with_container = _get_annotation_fields_with_container(type(self))
-        for field_name, container_type in annotation_fields_with_container.items():
+        reference_fields_with_container_type = _get_reference_fields_and_container_types(
+            type(self)
+        )
+        for field_name, container_type in reference_fields_with_container_type.items():
             if container_type is None:
                 overrides[field_name] = getattr(self, field_name)._id
             elif container_type == tuple:
@@ -237,8 +241,8 @@ class Annotation:
         annotation_store: Optional[Dict[int, "Annotation"]] = None,
     ):
         tmp_dct = dict(dct)
-        annotation_fields_with_container = _get_annotation_fields_with_container(cls)
-        for field_name, container_type in annotation_fields_with_container.items():
+        reference_fields_with_container_type = _get_reference_fields_and_container_types(cls)
+        for field_name, container_type in reference_fields_with_container_type.items():
             if container_type is None:
                 tmp_dct[field_name] = resolve_annotation(
                     tmp_dct[field_name], store=annotation_store

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -66,7 +66,8 @@ def _get_annotation_fields_with_container(cls: typing.Type) -> Dict[str, Any]:
         field_type = field.type
         # unwrap optional type
         if is_optional_type(field_type):
-            raise TypeError(f"optional type annotation is not allowed")
+            # raise TypeError(f"optional type annotation is not allowed")
+            continue
         if is_annotation_subclass(field_type):
             containers[field.name] = None
         type_args = typing.get_args(field_type)

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -1,0 +1,134 @@
+import dataclasses
+from typing import List, Optional, Tuple
+
+import pytest
+
+from pytorch_ie.annotations import Span
+from pytorch_ie.core import Annotation
+from pytorch_ie.core.document import (
+    _contains_annotation_type,
+    _get_annotation_fields_with_container,
+    _is_annotation_subclass,
+    _is_optional_type,
+    _is_tuple_of_annotations,
+)
+
+
+def test_is_optional_type():
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class Dummy:
+        a: int
+        b: Tuple[int, ...]
+        c: Optional[List[int]]
+        d: Optional[int] = None
+
+    fields = {field.name: field for field in dataclasses.fields(Dummy)}
+    assert not _is_optional_type(fields["a"].type)
+    assert not _is_optional_type(fields["b"].type)
+    assert _is_optional_type(fields["c"].type)
+    assert _is_optional_type(fields["d"].type)
+
+
+def test_is_annotation_subclass():
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class Dummy:
+        a: Span
+        b: Annotation
+        c: Optional[List[int]]
+        d: Optional[int] = None
+
+    fields = {field.name: field for field in dataclasses.fields(Dummy)}
+    assert _is_annotation_subclass(fields["a"].type)
+    assert _is_annotation_subclass(fields["b"].type)
+    assert not _is_annotation_subclass(fields["c"].type)
+    assert not _is_annotation_subclass(fields["d"].type)
+
+
+def test_contains_annotation_type():
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class Dummy:
+        a: Span
+        b: Annotation
+        c: int
+        d: Optional[List[Tuple[Optional[Span], ...]]]
+        e: Optional[int] = None
+
+    fields = {field.name: field for field in dataclasses.fields(Dummy)}
+    assert _contains_annotation_type(
+        fields["a"].type
+    ), f'field "a" does not contain an annotation type'
+    assert _contains_annotation_type(
+        fields["b"].type
+    ), f'field "b" does not contain an annotation type'
+    assert not _contains_annotation_type(
+        fields["c"].type
+    ), f'field "c" does contain an annotation type'
+    assert _contains_annotation_type(
+        fields["d"].type
+    ), f'field "d" does not contain an annotation type'
+    assert not _contains_annotation_type(
+        fields["e"].type
+    ), f'field "e" does not contain an annotation type'
+
+
+def test_is_tuple_of_annotations():
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class Dummy:
+        # a: no
+        a: Annotation
+        # b: no
+        b: int
+        # c: no, contains optional elements
+        c: Tuple[Optional[Span], ...]
+        # d: yes
+        d: Tuple[Span, ...]
+        # e: no, is optional
+        e: Optional[Tuple[Span, ...]]
+        # f: yes
+        f: Tuple[Span, Span]
+        # g: yes
+        g: Tuple[Span, ...]
+        # h: raise exception because it is mixed with non-Annotation type
+        h: Tuple[Span, int]
+        # i: raise no exception because it is mixed just with Annotation type subclasses
+        i: Tuple[Span, Annotation]
+
+    fields = {field.name: field for field in dataclasses.fields(Dummy)}
+    assert not _is_tuple_of_annotations(
+        fields["a"].type
+    ), f'field "a" is a pure tuple of annotation type'
+    assert not _is_tuple_of_annotations(
+        fields["b"].type
+    ), f'field "b" is a pure tuple of annotation type'
+    assert not _is_tuple_of_annotations(
+        fields["c"].type
+    ), f'field "c" is a pure tuple of annotation type'
+    assert _is_tuple_of_annotations(
+        fields["d"].type
+    ), f'field "d" is not a pure tuple of annotation type'
+    assert not _is_tuple_of_annotations(
+        fields["e"].type
+    ), f'field "e" is a pure tuple of annotation type'
+    assert _is_tuple_of_annotations(
+        fields["f"].type
+    ), f'field "f" is not a pure tuple of annotation type'
+    assert _is_tuple_of_annotations(
+        fields["g"].type
+    ), f'field "g" is not a pure tuple of annotation type'
+    with pytest.raises(TypeError):
+        _is_tuple_of_annotations(fields["h"].type)
+    assert _is_tuple_of_annotations(
+        fields["i"].type
+    ), f'field "i" is not a pure tuple of annotation type'
+
+
+def test_get_annotation_fields_with_container_exception():
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class Dummy:
+        a: Annotation
+        # This causes an exception because the type of by contains an Annotation subclass (Span),
+        # but it is embedded *twice* in a Tuple which is not allowed.
+        b: Tuple[Tuple[Span, ...]]
+
+    with pytest.raises(TypeError):
+        _get_annotation_fields_with_container(Dummy)

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -16,7 +16,7 @@ from pytorch_ie.core.document import (
 )
 
 
-def _test_reconstruct(
+def _test_annotation_reconstruction(
     annotation: Annotation, annotation_store: Optional[Dict[int, Annotation]] = None
 ):
     ann_str = json.dumps(annotation.asdict())
@@ -215,8 +215,8 @@ def test_annotation_with_optional_reference():
         tail._id: tail,
         trigger._id: trigger,
     }
-    _test_reconstruct(binary_relation1, annotation_store=annotation_store)
-    _test_reconstruct(binary_relation2, annotation_store=annotation_store)
+    _test_annotation_reconstruction(binary_relation1, annotation_store=annotation_store)
+    _test_annotation_reconstruction(binary_relation2, annotation_store=annotation_store)
 
 
 def test_annotation_with_tuple_of_references():
@@ -260,4 +260,4 @@ def test_annotation_with_tuple_of_references():
         evidence1._id: evidence1,
         evidence2._id: evidence2,
     }
-    _test_reconstruct(relation, annotation_store=annotation_store)
+    _test_annotation_reconstruction(relation, annotation_store=annotation_store)

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -7,7 +7,7 @@ from pytorch_ie.annotations import Span
 from pytorch_ie.core import Annotation
 from pytorch_ie.core.document import (
     _contains_annotation_type,
-    _get_annotation_fields_with_container,
+    _get_reference_fields_and_container_types,
     _is_annotation_subclass,
     _is_optional_type,
     _is_tuple_of_annotations,
@@ -131,4 +131,4 @@ def test_get_annotation_fields_with_container_exception():
         b: Tuple[Tuple[Span, ...]]
 
     with pytest.raises(TypeError):
-        _get_annotation_fields_with_container(Dummy)
+        _get_reference_fields_and_container_types(Dummy)

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -1,9 +1,10 @@
 import dataclasses
-from typing import List, Optional, Tuple
+import json
+from typing import Dict, List, Optional, Tuple
 
 import pytest
 
-from pytorch_ie.annotations import Span
+from pytorch_ie.annotations import Span, _post_init_single_label
 from pytorch_ie.core import Annotation
 from pytorch_ie.core.document import (
     _contains_annotation_type,
@@ -13,6 +14,16 @@ from pytorch_ie.core.document import (
     _is_optional_type,
     _is_tuple_of_annotation_types,
 )
+
+
+def _test_reconstruct(
+    annotation: Annotation, annotation_store: Optional[Dict[int, Annotation]] = None
+):
+    ann_str = json.dumps(annotation.asdict())
+    annotation_reconstructed = type(annotation).fromdict(
+        json.loads(ann_str), annotation_store=annotation_store
+    )
+    assert annotation_reconstructed == annotation
 
 
 def test_is_optional_type():
@@ -148,3 +159,105 @@ def test_get_reference_fields_and_container_types():
 
     with pytest.raises(TypeError):
         _get_reference_fields_and_container_types(Dummy)
+
+
+def test_annotation_with_optional_reference():
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class BinaryRelationWithOptionalTrigger(Annotation):
+        head: Span
+        tail: Span
+        label: str
+        trigger: Optional[Span] = None
+        score: float = 1.0
+
+        def __post_init__(self) -> None:
+            _post_init_single_label(self)
+
+    head = Span(start=1, end=2)
+    tail = Span(start=3, end=4)
+    trigger = Span(start=5, end=7)
+
+    binary_relation1 = BinaryRelationWithOptionalTrigger(head=head, tail=tail, label="label1")
+    assert binary_relation1.head == head
+    assert binary_relation1.tail == tail
+    assert binary_relation1.label == "label1"
+    assert binary_relation1.score == pytest.approx(1.0)
+
+    assert binary_relation1.asdict() == {
+        "_id": binary_relation1._id,
+        "head": head._id,
+        "tail": tail._id,
+        "trigger": None,
+        "label": "label1",
+        "score": 1.0,
+    }
+
+    binary_relation2 = BinaryRelationWithOptionalTrigger(
+        head=head, tail=tail, label="label2", score=0.5, trigger=trigger
+    )
+    assert binary_relation2.head == head
+    assert binary_relation2.tail == tail
+    assert binary_relation2.trigger == trigger
+    assert binary_relation2.label == "label2"
+    assert binary_relation2.score == pytest.approx(0.5)
+
+    assert binary_relation2.asdict() == {
+        "_id": binary_relation2._id,
+        "head": head._id,
+        "tail": tail._id,
+        "trigger": trigger._id,
+        "label": "label2",
+        "score": 0.5,
+    }
+
+    annotation_store = {
+        head._id: head,
+        tail._id: tail,
+        trigger._id: trigger,
+    }
+    _test_reconstruct(binary_relation1, annotation_store=annotation_store)
+    _test_reconstruct(binary_relation2, annotation_store=annotation_store)
+
+
+def test_annotation_with_tuple_of_references():
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class BinaryRelationWithEvidence(Annotation):
+        head: Span
+        tail: Span
+        label: str
+        evidence: Tuple[Span, ...]
+        score: float = 1.0
+
+        def __post_init__(self) -> None:
+            _post_init_single_label(self)
+
+    head = Span(start=1, end=2)
+    tail = Span(start=3, end=4)
+    evidence1 = Span(start=5, end=7)
+    evidence2 = Span(start=9, end=10)
+
+    relation = BinaryRelationWithEvidence(
+        head=head, tail=tail, label="label1", evidence=(evidence1, evidence2)
+    )
+    assert relation.head == head
+    assert relation.tail == tail
+    assert relation.label == "label1"
+    assert relation.score == pytest.approx(1.0)
+    assert relation.evidence == (evidence1, evidence2)
+
+    assert relation.asdict() == {
+        "_id": relation._id,
+        "head": head._id,
+        "tail": tail._id,
+        "evidence": [evidence1._id, evidence2._id],
+        "label": "label1",
+        "score": 1.0,
+    }
+
+    annotation_store = {
+        head._id: head,
+        tail._id: tail,
+        evidence1._id: evidence1,
+        evidence2._id: evidence2,
+    }
+    _test_reconstruct(relation, annotation_store=annotation_store)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -6,6 +6,8 @@ import pytest
 
 from pytorch_ie.annotations import (
     BinaryRelation,
+    BinaryRelationWithEvidence,
+    BinaryRelationWithOptionalTrigger,
     Label,
     LabeledMultiSpan,
     LabeledSpan,
@@ -276,3 +278,83 @@ def test_multilabeled_binary_relation():
         MultiLabeledBinaryRelation(
             head=head, tail=tail, label=("label5", "label6"), score=(0.1, 0.2, 0.3)
         )
+
+
+def test_binary_relation_with_optional_trigger():
+    head = Span(start=1, end=2)
+    tail = Span(start=3, end=4)
+    trigger = Span(start=5, end=7)
+
+    binary_relation1 = BinaryRelationWithOptionalTrigger(head=head, tail=tail, label="label1")
+    assert binary_relation1.head == head
+    assert binary_relation1.tail == tail
+    assert binary_relation1.label == "label1"
+    assert binary_relation1.score == pytest.approx(1.0)
+
+    assert binary_relation1.asdict() == {
+        "_id": binary_relation1._id,
+        "head": head._id,
+        "tail": tail._id,
+        "trigger": None,
+        "label": "label1",
+        "score": 1.0,
+    }
+
+    binary_relation2 = BinaryRelationWithOptionalTrigger(
+        head=head, tail=tail, label="label2", score=0.5, trigger=trigger
+    )
+    assert binary_relation2.head == head
+    assert binary_relation2.tail == tail
+    assert binary_relation2.trigger == trigger
+    assert binary_relation2.label == "label2"
+    assert binary_relation2.score == pytest.approx(0.5)
+
+    assert binary_relation2.asdict() == {
+        "_id": binary_relation2._id,
+        "head": head._id,
+        "tail": tail._id,
+        "trigger": trigger._id,
+        "label": "label2",
+        "score": 0.5,
+    }
+
+    annotation_store = {
+        head._id: head,
+        tail._id: tail,
+        trigger._id: trigger,
+    }
+    _test_reconstruct(binary_relation1, annotation_store=annotation_store)
+    _test_reconstruct(binary_relation2, annotation_store=annotation_store)
+
+
+def test_binary_relation_with_evidence():
+    head = Span(start=1, end=2)
+    tail = Span(start=3, end=4)
+    evidence1 = Span(start=5, end=7)
+    evidence2 = Span(start=9, end=10)
+
+    relation = BinaryRelationWithEvidence(
+        head=head, tail=tail, label="label1", evidence=(evidence1, evidence2)
+    )
+    assert relation.head == head
+    assert relation.tail == tail
+    assert relation.label == "label1"
+    assert relation.score == pytest.approx(1.0)
+    assert relation.evidence == (evidence1, evidence2)
+
+    assert relation.asdict() == {
+        "_id": relation._id,
+        "head": head._id,
+        "tail": tail._id,
+        "evidence": [evidence1._id, evidence2._id],
+        "label": "label1",
+        "score": 1.0,
+    }
+
+    annotation_store = {
+        head._id: head,
+        tail._id: tail,
+        evidence1._id: evidence1,
+        evidence2._id: evidence2,
+    }
+    _test_reconstruct(relation, annotation_store=annotation_store)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -13,7 +13,7 @@ from pytorch_ie.annotations import (
     MultiLabeledSpan,
     Span,
 )
-from tests.core.test_document import _test_reconstruct
+from tests.core.test_document import _test_annotation_reconstruction
 
 
 def test_label():
@@ -31,7 +31,7 @@ def test_label():
         "score": 0.5,
     }
 
-    _test_reconstruct(label2)
+    _test_annotation_reconstruction(label2)
 
 
 def test_multilabel():
@@ -49,7 +49,7 @@ def test_multilabel():
         "score": (0.4, 0.5),
     }
 
-    _test_reconstruct(multilabel2)
+    _test_annotation_reconstruction(multilabel2)
 
     with pytest.raises(
         ValueError, match=re.escape("Number of labels (2) and scores (3) must be equal.")
@@ -68,7 +68,7 @@ def test_span():
         "end": 2,
     }
 
-    _test_reconstruct(span)
+    _test_annotation_reconstruction(span)
 
 
 def test_labeled_span():
@@ -92,7 +92,7 @@ def test_labeled_span():
         "score": 0.5,
     }
 
-    _test_reconstruct(labeled_span2)
+    _test_annotation_reconstruction(labeled_span2)
 
 
 def test_multilabeled_span():
@@ -118,7 +118,7 @@ def test_multilabeled_span():
         "score": (0.4, 0.5),
     }
 
-    _test_reconstruct(multilabeled_span2)
+    _test_annotation_reconstruction(multilabeled_span2)
 
     with pytest.raises(
         ValueError, match=re.escape("Number of labels (2) and scores (3) must be equal.")
@@ -148,7 +148,7 @@ def test_labeled_multi_span():
         "score": 0.5,
     }
 
-    _test_reconstruct(labeled_multi_span2)
+    _test_annotation_reconstruction(labeled_multi_span2)
 
 
 def test_multilabeled_multi_span():
@@ -173,7 +173,7 @@ def test_multilabeled_multi_span():
         "score": (0.4, 0.5),
     }
 
-    _test_reconstruct(multilabeled_multi_span2)
+    _test_annotation_reconstruction(multilabeled_multi_span2)
 
     with pytest.raises(
         ValueError, match=re.escape("Number of labels (2) and scores (3) must be equal.")
@@ -211,7 +211,7 @@ def test_binary_relation():
         head._id: head,
         tail._id: tail,
     }
-    _test_reconstruct(binary_relation2, annotation_store=annotation_store)
+    _test_annotation_reconstruction(binary_relation2, annotation_store=annotation_store)
 
     with pytest.raises(
         ValueError,
@@ -250,7 +250,7 @@ def test_multilabeled_binary_relation():
         head._id: head,
         tail._id: tail,
     }
-    _test_reconstruct(binary_relation2, annotation_store=annotation_store)
+    _test_annotation_reconstruction(binary_relation2, annotation_store=annotation_store)
 
     with pytest.raises(
         ValueError,

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,13 +1,9 @@
-import json
 import re
-from typing import Dict, Optional
 
 import pytest
 
 from pytorch_ie.annotations import (
     BinaryRelation,
-    BinaryRelationWithEvidence,
-    BinaryRelationWithOptionalTrigger,
     Label,
     LabeledMultiSpan,
     LabeledSpan,
@@ -17,17 +13,7 @@ from pytorch_ie.annotations import (
     MultiLabeledSpan,
     Span,
 )
-from pytorch_ie.core import Annotation
-
-
-def _test_reconstruct(
-    annotation: Annotation, annotation_store: Optional[Dict[int, Annotation]] = None
-):
-    ann_str = json.dumps(annotation.asdict())
-    annotation_reconstructed = type(annotation).fromdict(
-        json.loads(ann_str), annotation_store=annotation_store
-    )
-    assert annotation_reconstructed == annotation
+from tests.core.test_document import _test_reconstruct
 
 
 def test_label():
@@ -278,83 +264,3 @@ def test_multilabeled_binary_relation():
         MultiLabeledBinaryRelation(
             head=head, tail=tail, label=("label5", "label6"), score=(0.1, 0.2, 0.3)
         )
-
-
-def test_binary_relation_with_optional_trigger():
-    head = Span(start=1, end=2)
-    tail = Span(start=3, end=4)
-    trigger = Span(start=5, end=7)
-
-    binary_relation1 = BinaryRelationWithOptionalTrigger(head=head, tail=tail, label="label1")
-    assert binary_relation1.head == head
-    assert binary_relation1.tail == tail
-    assert binary_relation1.label == "label1"
-    assert binary_relation1.score == pytest.approx(1.0)
-
-    assert binary_relation1.asdict() == {
-        "_id": binary_relation1._id,
-        "head": head._id,
-        "tail": tail._id,
-        "trigger": None,
-        "label": "label1",
-        "score": 1.0,
-    }
-
-    binary_relation2 = BinaryRelationWithOptionalTrigger(
-        head=head, tail=tail, label="label2", score=0.5, trigger=trigger
-    )
-    assert binary_relation2.head == head
-    assert binary_relation2.tail == tail
-    assert binary_relation2.trigger == trigger
-    assert binary_relation2.label == "label2"
-    assert binary_relation2.score == pytest.approx(0.5)
-
-    assert binary_relation2.asdict() == {
-        "_id": binary_relation2._id,
-        "head": head._id,
-        "tail": tail._id,
-        "trigger": trigger._id,
-        "label": "label2",
-        "score": 0.5,
-    }
-
-    annotation_store = {
-        head._id: head,
-        tail._id: tail,
-        trigger._id: trigger,
-    }
-    _test_reconstruct(binary_relation1, annotation_store=annotation_store)
-    _test_reconstruct(binary_relation2, annotation_store=annotation_store)
-
-
-def test_binary_relation_with_evidence():
-    head = Span(start=1, end=2)
-    tail = Span(start=3, end=4)
-    evidence1 = Span(start=5, end=7)
-    evidence2 = Span(start=9, end=10)
-
-    relation = BinaryRelationWithEvidence(
-        head=head, tail=tail, label="label1", evidence=(evidence1, evidence2)
-    )
-    assert relation.head == head
-    assert relation.tail == tail
-    assert relation.label == "label1"
-    assert relation.score == pytest.approx(1.0)
-    assert relation.evidence == (evidence1, evidence2)
-
-    assert relation.asdict() == {
-        "_id": relation._id,
-        "head": head._id,
-        "tail": tail._id,
-        "evidence": [evidence1._id, evidence2._id],
-        "label": "label1",
-        "score": 1.0,
-    }
-
-    annotation_store = {
-        head._id: head,
-        tail._id: tail,
-        evidence1._id: evidence1,
-        evidence2._id: evidence2,
-    }
-    _test_reconstruct(relation, annotation_store=annotation_store)


### PR DESCRIPTION
This PR introduces `_get_reference_fields_and_container_types()` that allows to collect all fields that are `Annotation` subclasses, i.e. that are meant to reference another annotation, e.g. `head` and `tail` references in the `BinaryRelation`. These references need special treatment during (de-)serialization because we store only their ids instead of the full objects to not create them multiple times when deserializing them. By using `_get_reference_fields_and_container_types()` we can now handle the most common cases automatically: 
1. annotations containing fields that reference any other annotation (example below: `head` or `tail`), 
2. tuples of 1. (example below: `evidence`), and 
3. optional versions of 1. (example below: `trigger`). 

This means, there is **no need to overwrite** `asdict()` and `fromdict()` for such cases anymore and sth like this just works:

```python
@dataclass(eq=True, frozen=True)
class BinaryRelationWithEvidenceAndTrigger(Annotation):
    head: LabeledSpan
    tail: LabeledSpan
    label: str
    evidence: Tuple[Span, ...]
    trigger: Optional[Span] = None
    score: float = 1.0

    def __post_init__(self) -> None:
        _post_init_single_label(self)

```

Note: This also moves `tests.test_annotations._test_reconstruct()` to `tests.core.test_document._test_annotation_reconstruction()`.