### PR TITLE
implement ArrowBasedBuilder

### DIFF
--- a/src/pytorch_ie/data/builder.py
+++ b/src/pytorch_ie/data/builder.py
@@ -1,15 +1,12 @@
 import abc
 from typing import Any, Dict, Optional, Type, Union, overload
 
-from datasets import Dataset as HfDataset
-from datasets import DatasetDict
-from datasets import IterableDataset as HfIterableDataset
-from datasets import IterableDatasetDict, Split, builder, load
+import datasets as hf_datasets
 from pytorch_ie.core.document import Document
 from pytorch_ie.data.dataset import Dataset, IterableDataset, decorate_convert_to_dict_of_lists
 
 
-class PieDatasetBuilder(builder.DatasetBuilder):
+class PieDatasetBuilder(hf_datasets.builder.DatasetBuilder):
     DOCUMENT_TYPE: Optional[Type[Document]] = None
 
     BASE_DATASET_PATH: Optional[str] = None
@@ -46,7 +43,7 @@ class PieDatasetBuilder(builder.DatasetBuilder):
                 base_builder_kwargs.update(self.BASE_BUILDER_KWARGS_DICT[config_name])
 
             base_builder_kwargs.update(base_dataset_kwargs)
-            self.base_builder = load.load_dataset_builder(
+            self.base_builder = hf_datasets.load.load_dataset_builder(
                 path=self.BASE_DATASET_PATH,
                 **base_builder_kwargs,
             )
@@ -67,15 +64,15 @@ class PieDatasetBuilder(builder.DatasetBuilder):
         return None
 
     @overload
-    def _convert_dataset_single(self, dataset: HfDataset) -> Dataset:
+    def _convert_dataset_single(self, dataset: hf_datasets.Dataset) -> Dataset:
         ...
 
     @overload
-    def _convert_dataset_single(self, dataset: HfIterableDataset) -> IterableDataset:
+    def _convert_dataset_single(self, dataset: hf_datasets.IterableDataset) -> IterableDataset:
         ...
 
     def _convert_dataset_single(
-        self, dataset: Union[HfDataset, HfIterableDataset]
+        self, dataset: Union[hf_datasets.Dataset, hf_datasets.IterableDataset]
     ) -> Union[Dataset, IterableDataset]:
         if self.DOCUMENT_TYPE is None:
             raise TypeError("the builder has no DOCUMENT_TYPE defined")
@@ -85,37 +82,45 @@ class PieDatasetBuilder(builder.DatasetBuilder):
         fn_kwargs = self._generate_document_kwargs(dataset)
         mapped_dataset = dataset.map(fn, fn_kwargs=fn_kwargs)
 
-        if isinstance(mapped_dataset, HfDataset):
+        if isinstance(mapped_dataset, hf_datasets.Dataset):
             return Dataset.from_hf_dataset(dataset=mapped_dataset, document_type=document_type)
-        elif isinstance(mapped_dataset, HfIterableDataset):
+        elif isinstance(mapped_dataset, hf_datasets.IterableDataset):
             return IterableDataset.from_hf_dataset(
                 dataset=mapped_dataset, document_type=document_type
             )
         else:
             raise TypeError(
                 f"hugginggface dataset has unknown type: {type(mapped_dataset).__name__}. Expected: "
-                f"{HfDataset.__name__} or {HfIterableDataset.__name__}"
+                f"{hf_datasets.Dataset.__name__} or {hf_datasets.IterableDataset.__name__}"
             )
 
     @overload
-    def _convert_datasets(self, datasets: HfDataset) -> Dataset:
+    def _convert_datasets(self, datasets: hf_datasets.Dataset) -> Dataset:
         ...
 
     @overload
-    def _convert_datasets(self, datasets: HfIterableDataset) -> IterableDataset:
+    def _convert_datasets(self, datasets: hf_datasets.IterableDataset) -> IterableDataset:
         ...
 
     @overload
-    def _convert_datasets(self, datasets: DatasetDict) -> DatasetDict:
+    def _convert_datasets(self, datasets: hf_datasets.DatasetDict) -> hf_datasets.DatasetDict:
         ...
 
     @overload
-    def _convert_datasets(self, datasets: IterableDatasetDict) -> IterableDatasetDict:
+    def _convert_datasets(
+        self, datasets: hf_datasets.IterableDatasetDict
+    ) -> hf_datasets.IterableDatasetDict:
         ...
 
     def _convert_datasets(
-        self, datasets: Union[HfDataset, HfIterableDataset, DatasetDict, IterableDatasetDict]
-    ) -> Union[Dataset, IterableDataset, DatasetDict, IterableDatasetDict]:
+        self,
+        datasets: Union[
+            hf_datasets.Dataset,
+            hf_datasets.IterableDataset,
+            hf_datasets.DatasetDict,
+            hf_datasets.IterableDatasetDict,
+        ],
+    ) -> Union[Dataset, IterableDataset, hf_datasets.DatasetDict, hf_datasets.IterableDatasetDict]:
         if isinstance(datasets, dict):
             return type(datasets)(
                 {k: self._convert_dataset_single(v) for k, v in datasets.items()}
@@ -125,11 +130,11 @@ class PieDatasetBuilder(builder.DatasetBuilder):
 
     def as_dataset(
         self,
-        split: Optional[Split] = None,
+        split: Optional[hf_datasets.Split] = None,
         run_post_process=True,
         ignore_verifications=False,
         in_memory=False,
-    ) -> Union[Dataset, DatasetDict]:
+    ) -> Union[Dataset, hf_datasets.DatasetDict]:
         datasets = super().as_dataset(
             split=split,
             run_post_process=run_post_process,
@@ -144,16 +149,18 @@ class PieDatasetBuilder(builder.DatasetBuilder):
         split: Optional[str] = None,
         base_path: Optional[str] = None,
     ) -> Union[IterableDataset, IterableDatasetDict]:  # type: ignore
-        datasets: Union[HfIterableDataset, IterableDatasetDict] = super().as_streaming_dataset(split=split, base_path=base_path)  # type: ignore
+        datasets: Union[hf_datasets.IterableDataset, hf_datasets.IterableDatasetDict] = super().as_streaming_dataset(
+            split=split, base_path=base_path
+        )  # type: ignore
         converted_datasets = self._convert_datasets(datasets=datasets)
         return converted_datasets
 
 
-class GeneratorBasedBuilder(PieDatasetBuilder, builder.GeneratorBasedBuilder):
+class GeneratorBasedBuilder(PieDatasetBuilder, hf_datasets.builder.GeneratorBasedBuilder):
     def _generate_examples(self, *args, **kwargs):
         return self.base_builder._generate_examples(*args, **kwargs)
 
 
-class ArrowBasedBuilder(PieDatasetBuilder, builder.ArrowBasedBuilder):
+class ArrowBasedBuilder(PieDatasetBuilder, hf_datasets.builder.ArrowBasedBuilder):
     def _generate_tables(self, *args, **kwargs):
         return self.base_builder._generate_tables(*args, **kwargs)

--- a/src/pytorch_ie/data/builder.py
+++ b/src/pytorch_ie/data/builder.py
@@ -148,8 +148,10 @@ class PieDatasetBuilder(hf_datasets.builder.DatasetBuilder):
         self,
         split: Optional[str] = None,
         base_path: Optional[str] = None,
-    ) -> Union[IterableDataset, IterableDatasetDict]:  # type: ignore
-        datasets: Union[hf_datasets.IterableDataset, hf_datasets.IterableDatasetDict] = super().as_streaming_dataset(
+    ) -> Union[IterableDataset, hf_datasets.IterableDatasetDict]:  # type: ignore
+        datasets: Union[
+            hf_datasets.IterableDataset, hf_datasets.IterableDatasetDict
+        ] = super().as_streaming_dataset(
             split=split, base_path=base_path
         )  # type: ignore
         converted_datasets = self._convert_datasets(datasets=datasets)

--- a/tests/data/test_builder.py
+++ b/tests/data/test_builder.py
@@ -121,3 +121,22 @@ def test_builder_class_name_mapping_and_defaults():
         assert builder.info.config_name == "nl"
         assert builder.base_builder.info.config_name == "default"
         assert builder.base_builder.info.version == "0.0.0"
+
+
+def test_wrong_builder_class_config():
+    dataset_module = dataset_module_factory(str(DATASETS_ROOT / "wrong_builder_class_config"))
+    builder_cls = import_main_class(dataset_module.module_path)
+    with tempfile.TemporaryDirectory() as tmp_cache_dir:
+        # This should raise an exception because the base builder is derived from GeneratorBasedBuilder,
+        # but the PIE dataset builder is derived from ArrowBasedBuilder.
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "The PyTorch-IE dataset builder class 'Example' is derived from "
+                "<class 'datasets.builder.ArrowBasedBuilder'>, but the base builder is not which is not allowed. "
+                "The base builder is of type 'Conll2003' that is derived from "
+                "<class 'datasets.builder.GeneratorBasedBuilder'>. Consider to derive your PyTorch-IE dataset builder "
+                "'Example' from a PyTorch-IE variant of 'GeneratorBasedBuilder'."
+            ),
+        ):
+            builder_cls(cache_dir=tmp_cache_dir)

--- a/tests/fixtures/builder/datasets/wrong_builder_class_config/wrong_builder_class_config.py
+++ b/tests/fixtures/builder/datasets/wrong_builder_class_config/wrong_builder_class_config.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from typing import Type
+
+import datasets
+import pytorch_ie.data.builder
+from pytorch_ie.annotations import LabeledSpan
+from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.documents import TextDocument
+from tests import FIXTURES_ROOT
+
+
+class ExampleConfig(datasets.BuilderConfig):
+    """BuilderConfig for CoNLL2003"""
+
+    def __init__(self, parameter: str, **kwargs):
+        """BuilderConfig for CoNLL2003.
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
+        super().__init__(**kwargs)
+        self.parameter = parameter
+
+
+@dataclass
+class ExampleDocument(TextDocument):
+    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+
+
+class Example(pytorch_ie.data.builder.ArrowBasedBuilder):
+    DOCUMENT_TYPE = ExampleDocument
+
+    BASE_DATASET_PATH = str(FIXTURES_ROOT / "builder" / "datasets" / "base_single_config")
+
+    BUILDER_CONFIGS = [
+        ExampleConfig(
+            name="conll2003",
+            version=datasets.Version("1.0.0"),
+            description="Example dataset",
+            parameter="test",
+        ),
+    ]
+
+    # required to create config from scratch via kwargs
+    BUILDER_CONFIG_CLASS: Type[datasets.BuilderConfig] = ExampleConfig
+
+    def _generate_document_kwargs(self, dataset):
+        pass
+
+    def _generate_document(self, example, int_to_str):
+        pass


### PR DESCRIPTION
This PR implements a PIE version of the `ArrowBasedBuilder` in analogy to the `GeneratorBasedBuilder`. The `ArrowBasedBuilder` is required for any PIE dataset builder that has an `ArrowBasedBuilder` as base_builder such as generic tabular data builders from Huggingface (pandas, parquet, json, sql, text, csv).

To do so, this PR introduces an abstract class `PieDatasetBuilder`. This class is a cleaned version of the previous PIE `GeneratorBasedBuilder`: It primarily overwrites `as_dataset()` and `as_streaming_dataset()`, which are the two entry points to get actual datasets from a Huggingface `DatasetBuilder`, by wrapping the Huggingface datasets into PIE datasets.  

Finally, the PIE variants `GeneratorBasedBuilder` and `ArrowBasedBuilder` derive from that new class and just implement the required functions, `_generate_examples()` and `_generate_tables()`, by calling these from the base_builder. This approach should be future proof, e.g. if a PIE variant of `BeamBasedBuilder` is required, this should be easily implemented in the same fashion. Furthermore, the surface with Huggingface is quite low, i.e. we just need to be aware of changes in the result of `as_dataset()` and `as_streaming_dataset()`. But these methods should be quite stable because it is less internal then the ones we have overwritten before this PR (`_as_dataset()` and `_as_streaming_dataset_single()`). 

We throw an exception if the PIE dataset builder is incompatible with the base builder. 