### PR TITLE
minor data model improvements

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -537,10 +537,19 @@ class Document(Mapping[str, Any]):
         return doc
 
     def as_type(
-        self, new_type: typing.Type[D], field_mapping: Optional[Dict[str, str]] = None
+        self,
+        new_type: typing.Type[D],
+        field_mapping: Optional[Dict[str, str]] = None,
+        keep_remaining: bool = True,
     ) -> D:
         field_mapping = field_mapping or {}
-        new_doc = new_type.fromdict({field_mapping.get(k, k): v for k, v in self.asdict().items()})
+        new_doc = new_type.fromdict(
+            {
+                field_mapping.get(k, k): v
+                for k, v in self.asdict().items()
+                if keep_remaining or k in field_mapping
+            }
+        )
         return new_doc
 
 

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -105,7 +105,6 @@ def _check_fields_for_casting(
         new_f = new_fields[f_name_mapped]
         if not (
             f.type == new_f.type
-            and f.metadata == new_f.metadata
             and f.default == new_f.default
             and f.default_factory == new_f.default_factory
         ):


### PR DESCRIPTION
This PR
- removes the check for metadata equality of the old fields with respect to their new counterparts when casting a dataset. This caused problems because the target names are saved in metadata, so casting a dataset with also renaming fields would result in different metadata content which is totally fine, but raised an error so far.
- adds a boolean parameter `keep_remaining` (default: `True`) to `Document.as_type()` to disable copying over all fields that are not mentioned in `field_mapping`. That caused problems if the old type contains fields that are not useful for the new type.  