### PR TITLE
specify version of poetry-core (build-system)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core>=1.6.0;<2.0.0"]
+requires = ["poetry-core ~=1.6"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
-# requires = ["poetry-core>=1.1.0"]
-requires = ["poetry-core @ git+https://github.com/python-poetry/poetry-core.git@master"]
+requires = ["poetry-core>=1.6.0;<2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]


### PR DESCRIPTION
It looks like it is is not anymore possible to just use the master branch (caused errors in downstream projects).