### PR TITLE
rework TransformerRETextClassificationTaskModule

### DIFF
--- a/examples/predict/re_text_classification.py
+++ b/examples/predict/re_text_classification.py
@@ -16,7 +16,9 @@ class ExampleDocument(TextDocument):
 
 def main():
     model_name_or_path = "pie/example-re-textclf-tacred"
-    re_taskmodule = TransformerRETextClassificationTaskModule.from_pretrained(model_name_or_path)
+    re_taskmodule = TransformerRETextClassificationTaskModule.from_pretrained(
+        model_name_or_path, create_relation_candidates=True
+    )
     re_model = TransformerTextClassificationModel.from_pretrained(model_name_or_path)
 
     re_pipeline = Pipeline(model=re_model, taskmodule=re_taskmodule, device=-1)

--- a/tests/fixtures/datasets/json/train.json
+++ b/tests/fixtures/datasets/json/train.json
@@ -89,7 +89,7 @@
             }
         },
         {
-            "id": "val_doc1",
+            "id": "train_doc7",
             "text": "A single sentence.",
             "sentences": [{ "start": 0, "end": 18 }],
             "entities": [],
@@ -99,25 +99,26 @@
             }
         },
         {
-            "id": "val_doc2",
-            "text": "First sentence. Entity M works at N. And founded O.",
+            "id": "train_doc8",
+            "text": "First sentence. Entity M works at N. And it founded O.",
             "sentences": [
                 { "start": 0, "end": 15 },
                 { "start": 16, "end": 36 },
-                { "start": 16, "end": 51 }
+                { "start": 37, "end": 53 }
             ],
             "entities": [
                 { "start": 16, "end": 24, "label": "PER" },
                 { "start": 34, "end": 35, "label": "ORG" },
-                { "start": 49, "end": 50, "label": "ORG" }
+                { "start": 41, "end": 43, "label": "PER" },
+                { "start": 52, "end": 53, "label": "ORG" }
             ],
             "relations": [
                 { "head": 0, "tail": 1, "label": "per:employee_of" },
-                { "head": 0, "tail": 2, "label": "per:founder" },
-                { "head": 2, "tail": 1, "label": "org:founded_by" }
+                { "head": 2, "tail": 3, "label": "per:founder" },
+                { "head": 3, "tail": 2, "label": "org:founded_by" }
             ],
             "metadata": {
-                "description": "sentences with multiple relation annotations and cross-sentence relation"
+                "description": "sentences with multiple relation annotations in different sentences"
             }
         }
     ]

--- a/tests/pipeline/test_re_text_classification.py
+++ b/tests/pipeline/test_re_text_classification.py
@@ -46,30 +46,29 @@ def test_re_text_classification(use_auto):
 
     pipeline(document, batch_size=2)
     relations: Sequence[BinaryRelation] = document["relations"].predictions
-    assert len(relations) == 4
+    assert len(relations) == 3
 
-    sorted_relations = sorted(relations, key=lambda rel: (rel.head.start + rel.tail.start) / 2)
+    rels = sorted(relations, key=lambda rel: (rel.head.start + rel.tail.start) / 2)
 
-    relation0 = sorted_relations[0]
-    assert relation0.label == "per:employee_of"
-    assert relation0.score == pytest.approx(0.96, abs=1e-2)
-    assert (relation0.head.start, relation0.head.end) == (65, 75)
-    assert (relation0.tail.start, relation0.tail.end) == (96, 100)
+    # Note: The scores are quite low, because the model is trained with the old version for the taskmodule,
+    # so the argument markers are not correct.
+    assert (str(rels[0].head), rels[0].label, str(rels[0].tail)) == (
+        "SOSV",
+        "org:top_members/employees",
+        "Po Bronson",
+    )
+    assert rels[0].score == pytest.approx(0.398, abs=1e-2)
 
-    relation1 = sorted_relations[1]
-    assert relation1.label == "org:top_members/employees"
-    assert relation1.score == pytest.approx(0.71, abs=1e-2)
-    assert (relation1.head.start, relation1.head.end) == (96, 100)
-    assert (relation1.tail.start, relation1.tail.end) == (65, 75)
+    assert (str(rels[1].head), rels[1].label, str(rels[1].tail)) == (
+        "Po Bronson",
+        "per:employee_of",
+        "IndieBio",
+    )
+    assert rels[1].score == pytest.approx(0.534, abs=1e-2)
 
-    relation2 = sorted_relations[2]
-    assert relation2.label == "per:employee_of"
-    assert relation2.score == pytest.approx(0.94, abs=1e-2)
-    assert (relation2.head.start, relation2.head.end) == (65, 75)
-    assert (relation2.tail.start, relation2.tail.end) == (126, 134)
-
-    relation3 = sorted_relations[3]
-    assert relation3.label == "org:top_members/employees"
-    assert relation3.score == pytest.approx(0.85, abs=1e-2)
-    assert (relation3.head.start, relation3.head.end) == (126, 134)
-    assert (relation3.tail.start, relation3.tail.end) == (65, 75)
+    assert (str(rels[2].head), rels[2].label, str(rels[2].tail)) == (
+        "IndieBio",
+        "org:top_members/employees",
+        "Po Bronson",
+    )
+    assert rels[2].score == pytest.approx(0.552, abs=1e-2)

--- a/tests/pipeline/test_re_text_classification.py
+++ b/tests/pipeline/test_re_text_classification.py
@@ -23,10 +23,13 @@ class ExampleDocument(TextDocument):
 def test_re_text_classification(use_auto):
     model_name_or_path = "pie/example-re-textclf-tacred"
     if use_auto:
-        pipeline = AutoPipeline.from_pretrained(model_name_or_path)
+        pipeline = AutoPipeline.from_pretrained(
+            model_name_or_path, taskmodule_kwargs={"create_relation_candidates": True}
+        )
     else:
         re_taskmodule = TransformerRETextClassificationTaskModule.from_pretrained(
-            model_name_or_path
+            model_name_or_path,
+            create_relation_candidates=True,
         )
         re_model = TransformerTextClassificationModel.from_pretrained(model_name_or_path)
         pipeline = Pipeline(model=re_model, taskmodule=re_taskmodule, device=-1)
@@ -34,7 +37,8 @@ def test_re_text_classification(use_auto):
     assert pipeline.model.is_from_pretrained
 
     document = ExampleDocument(
-        "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
+        "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner "
+        "at SOSV and managing director of IndieBio."
     )
 
     for start, end, label in [(65, 75, "PER"), (96, 100, "ORG"), (126, 134, "ORG")]:


### PR DESCRIPTION
Important: This is not backwards compatible because 
 - the `argument_markers` are constructed in a different (but reproducible) order! That means, models trained with a previous version do not work with this one because the token ids of the argument markers depend on the insertion order when adding them to the tokenizer vocab.
 - this requires to explicitly set `create_relation_candidates=True` if no relations are available, e.g. when used for inference on documents that are created from scratch