### PR TITLE
token classification taskmodule: skip docs with overlapping spans

### DIFF
--- a/src/pytorch_ie/taskmodules/transformer_token_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_token_classification.py
@@ -341,7 +341,7 @@ class TransformerTokenClassificationTaskModule(_TransformerTokenClassificationTa
             task_encoding.targets for task_encoding in task_encodings
         ]
 
-        sequence_length = torch.tensor(inputs["input_ids"]).shape[1]
+        sequence_length = inputs["input_ids"].shape[1]
         padding_side = self.tokenizer.padding_side
         if padding_side == "right":
             target_list_padded = [
@@ -354,7 +354,6 @@ class TransformerTokenClassificationTaskModule(_TransformerTokenClassificationTa
                 for t in target_list
             ]
 
-        inputs = {k: torch.tensor(v, dtype=torch.int64) for k, v in inputs.items()}
         targets = torch.tensor(target_list_padded, dtype=torch.int64)
 
         return inputs, targets

--- a/src/pytorch_ie/utils/span.py
+++ b/src/pytorch_ie/utils/span.py
@@ -165,7 +165,7 @@ def convert_span_annotations_to_tag_sequence(
     char_to_token_mapper: Callable[[int], Optional[int]],
     partition: Optional[Span] = None,
     statistics: Optional[DefaultDict[str, Counter]] = None,
-) -> MutableSequence[Optional[str]]:
+) -> Optional[MutableSequence[Optional[str]]]:
     """
     Given a list of span annotations, a character position to token mapper (as obtained from
     batch_encoding.char_to_token) and a special tokens mask, create a sequence of tags with the length of the
@@ -199,8 +199,8 @@ def convert_span_annotations_to_tag_sequence(
 
         for j in range(start_idx, end_idx + 1):
             if tag_sequence[j] is not None and tag_sequence[j] != "O":
-                # TODO: is ValueError a good exception type for this?
-                raise ValueError(f"tag already assigned (current span has an overlap: {span})")
+                logger.warning(f"tag already assigned (current span has an overlap: {span}).")
+                return None
             prefix = "B" if j == start_idx else "I"
             tag_sequence[j] = f"{prefix}-{span.label}"
 


### PR DESCRIPTION
Skip the document with a warning instead of raising an error if there are overlapping spans. This also removes two other pytorch warnings.