### PR TITLE
fix relative paths in base dataset builder

### DIFF
--- a/src/pytorch_ie/data/builder.py
+++ b/src/pytorch_ie/data/builder.py
@@ -89,6 +89,10 @@ class PieDatasetBuilder(hf_datasets.builder.DatasetBuilder):
             if "hash" in kwargs:
                 kwargs["hash"] = f"{kwargs['hash']}-{self.base_builder.config_id}"
 
+            # set base path to base builder base path. This is required so that the download manager
+            # works correctly with relative paths.
+            kwargs["base_path"] = self.base_builder.base_path
+
         super().__init__(**kwargs)
 
     def _info(self):


### PR DESCRIPTION
If a HF dataset loading script references relative data urls (see [docred](https://huggingface.co/datasets/docred) for an example), using this as base dataset within a PIE dataset loading script was broken. This PR fixes this issue by setting the  `base_path` of the PIE script to the `base_path` of the HF script.