### PR TITLE
BaseAnnotationList.clear() returns the contained annotations

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -337,6 +337,9 @@ class BaseAnnotationList(Sequence[T]):
         return f"BaseAnnotationList({str(self._annotations)})"
 
     def clear(self) -> List[T]:
+        """
+        Detach all annotations from the layer and return them.
+        """
         result = list(self._annotations)
         for annotation in self._annotations:
             annotation.set_targets(None)

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -336,12 +336,14 @@ class BaseAnnotationList(Sequence[T]):
     def __repr__(self) -> str:
         return f"BaseAnnotationList({str(self._annotations)})"
 
-    def clear(self):
+    def clear(self) -> List[T]:
+        result = list(self._annotations)
         for annotation in self._annotations:
             annotation.set_targets(None)
         self._annotations = []
+        return result
 
-    def pop(self, index: int = -1):
+    def pop(self, index: int = -1) -> T:
         ann = self._annotations.pop(index)
         ann.set_targets(None)
         return ann


### PR DESCRIPTION
It is sometimes the case that we want to do sth. with the cleared (detached) annotations, e.g. when we want to move them to another annotation layer (AnnotationList), from predictions to main annotations or to another document.