### PR TITLE
add Annotation.copy()

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -275,6 +275,10 @@ class Annotation:
         tmp_dct.pop("_id", None)
         return cls(**tmp_dct)
 
+    @property
+    def is_attached(self) -> bool:
+        return self._targets is not None
+
 
 T = TypeVar("T", covariant=False, bound="Annotation")
 

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -279,6 +279,21 @@ class Annotation:
     def is_attached(self) -> bool:
         return self._targets is not None
 
+    def copy(self, **overrides) -> "Annotation":
+        """
+        Create a detached copy of the annotation with the same values as the original.
+
+        :param overrides: keyword arguments to override the values of the original annotation
+        :return: a detached copy of the annotation
+        """
+        kwargs = {}
+        for f in dataclasses.fields(self):
+            if f.name == "_targets":
+                continue
+            kwargs[f.name] = getattr(self, f.name)
+        kwargs.update(overrides)
+        return type(self)(**kwargs)
+
 
 T = TypeVar("T", covariant=False, bound="Annotation")
 

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -322,7 +322,7 @@ class BaseAnnotationList(Sequence[T]):
             annotation.set_targets(None)
         self._annotations = []
 
-    def pop(self, index=None):
+    def pop(self, index: int = -1):
         ann = self._annotations.pop(index)
         ann.set_targets(None)
         return ann

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Tuple
 
 import pytest
 
-from pytorch_ie.annotations import Span, _post_init_single_label
 from pytorch_ie.core import Annotation
 from pytorch_ie.core.document import (
     AnnotationList,
@@ -17,6 +16,12 @@ from pytorch_ie.core.document import (
     _is_tuple_of_annotation_types,
     annotation_field,
 )
+
+
+@dataclasses.dataclass(eq=True, frozen=True)
+class Span(Annotation):
+    start: int
+    end: int
 
 
 def _test_annotation_reconstruction(
@@ -173,9 +178,6 @@ def test_annotation_with_optional_reference():
         trigger: Optional[Span] = None
         score: float = 1.0
 
-        def __post_init__(self) -> None:
-            _post_init_single_label(self)
-
     head = Span(start=1, end=2)
     tail = Span(start=3, end=4)
     trigger = Span(start=5, end=7)
@@ -230,9 +232,6 @@ def test_annotation_with_tuple_of_references():
         label: str
         evidence: Tuple[Span, ...]
         score: float = 1.0
-
-        def __post_init__(self) -> None:
-            _post_init_single_label(self)
 
     head = Span(start=1, end=2)
     tail = Span(start=3, end=4)

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -7,12 +7,15 @@ import pytest
 from pytorch_ie.annotations import Span, _post_init_single_label
 from pytorch_ie.core import Annotation
 from pytorch_ie.core.document import (
+    AnnotationList,
+    Document,
     _contains_annotation_type,
     _get_reference_fields_and_container_types,
     _is_annotation_type,
     _is_optional_annotation_type,
     _is_optional_type,
     _is_tuple_of_annotation_types,
+    annotation_field,
 )
 
 
@@ -261,3 +264,18 @@ def test_annotation_with_tuple_of_references():
         evidence2._id: evidence2,
     }
     _test_annotation_reconstruction(relation, annotation_store=annotation_store)
+
+
+def test_annotation_is_attached():
+    @dataclasses.dataclass
+    class MyDocument(Document):
+        text: str
+        words: AnnotationList[Span] = annotation_field(target="text")
+
+    document = MyDocument(text="Hello world!")
+    word = Span(start=0, end=5)
+    assert not word.is_attached
+    document.words.append(word)
+    assert word.is_attached
+    document.words.pop()
+    assert not word.is_attached


### PR DESCRIPTION
Changes within this PR:
 - set index = -1 as default value for `BasAnnotationList.pop()` (was `None` before which caused an Exception)
 - add `Annotation.is_attached` property that returns True iff `_targets` is set
 - add `Annotation.copy(**overrides)`: Create a detached copy of the annotation with the same values as the original (allows overrides).