### PR TITLE
implement target getters for BaseAnnotationList

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -351,6 +351,22 @@ class BaseAnnotationList(Sequence[T]):
         ann.set_targets(None)
         return ann
 
+    @property
+    def target_layers(self) -> dict[str, "AnnotationList"]:
+        return {
+            target_layer_name: self._document[target_layer_name]
+            for target_layer_name in self._targets
+            if target_layer_name in self._document
+        }
+
+    @property
+    def target_fields(self) -> dict[str, Any]:
+        return {
+            target_field_name: getattr(self, target_field_name)
+            for target_field_name in self._targets
+            if hasattr(self, target_field_name)
+        }
+
 
 class AnnotationList(BaseAnnotationList[T]):
     def __init__(self, document: "Document", targets: List["str"]):

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -352,20 +352,37 @@ class BaseAnnotationList(Sequence[T]):
         return ann
 
     @property
-    def target_layers(self) -> dict[str, "AnnotationList"]:
+    def targets(self) -> dict[str, Any]:
         return {
-            target_layer_name: self._document[target_layer_name]
-            for target_layer_name in self._targets
-            if target_layer_name in self._document
+            target_field_name: getattr(self._document, target_field_name)
+            for target_field_name in self._targets
         }
 
     @property
-    def target_fields(self) -> dict[str, Any]:
+    def target(self) -> Any:
+        tgts = self.targets
+        if len(tgts) != 1:
+            raise ValueError(
+                f"The annotation layer has more or less than one target: {self._targets}"
+            )
+        return list(tgts.values())[0]
+
+    @property
+    def target_layers(self) -> dict[str, "AnnotationList"]:
         return {
-            target_field_name: getattr(self, target_field_name)
-            for target_field_name in self._targets
-            if hasattr(self, target_field_name)
+            target_name: target
+            for target_name, target in self.targets.items()
+            if isinstance(target, AnnotationList)
         }
+
+    @property
+    def target_layer(self) -> "AnnotationList":
+        tgt_layers = self.target_layers
+        if len(tgt_layers) != 1:
+            raise ValueError(
+                f"The annotation layer has more or less than one target layer: {list(tgt_layers.keys())}"
+            )
+        return list(tgt_layers.values())[0]
 
 
 class AnnotationList(BaseAnnotationList[T]):


### PR DESCRIPTION
This PR add the properties the following properties to `BaseAnnotationList`: 
- `tagets`: return all targets of the annotation layer as dictionary
- `target`: Target accessor for the annotation layer if it has only one target.
- `target_layers`: return all target layers of the annotation layer as dictionary.
- `target_layer`: Target layer accessor for the annotation layer if it has only one target layer.

Note: We add `target` and `target_layer` because most of the layers have just a single target.  