### PR TITLE
include non-comparison annotion fields in the _id calculation

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -192,8 +192,17 @@ class Annotation:
         object.__setattr__(self, "_targets", value)
 
     @property
+    def non_comparison_fields_and_values(self) -> Tuple[Tuple[str, Any], ...]:
+        return tuple(
+            (f.name, getattr(self, f.name)) for f in dataclasses.fields(self) if not f.compare
+        )
+
+    @property
     def _id(self) -> int:
-        return hash(self)
+        # also calculate the hash over the non-comparison fields for id creation because otherwise
+        # these fields would not be considered (per default, hash=false for non-comparison fields)
+        # and (de-)serialization would de-duplicate annotations that vary just in these fields
+        return hash((self, self.non_comparison_fields_and_values))
 
     @property
     def target(self) -> Optional[TARGET_TYPE]:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -567,24 +567,36 @@ def test_annotation_list_targets():
 
 def test_annotation_compare():
     @dataclasses.dataclass(eq=True, frozen=True)
-    class MyAnnotation(Annotation):
+    class TestAnnotation(Annotation):
         value: str
         # Note that the score field is marked as not comparable
         score: Optional[float] = dataclasses.field(compare=False, default=None)
 
-    annotation0 = MyAnnotation(value="test")
-    annotation1 = MyAnnotation(value="test", score=0.9)
-    annotation2 = MyAnnotation(value="test", score=0.5)
+    annotation0 = TestAnnotation(value="test")
+    annotation1 = TestAnnotation(value="test", score=0.9)
+    annotation2 = TestAnnotation(value="test", score=0.5)
 
     assert hash(annotation0) == hash(annotation1) == hash(annotation2)
     assert annotation0 == annotation1 and annotation0 == annotation2
 
     # annotation id is equal if the annotation is the same
-    assert annotation0._id == MyAnnotation(value="test")._id
-    assert annotation1._id == MyAnnotation(value="test", score=0.9)._id
-    assert annotation2._id == MyAnnotation(value="test", score=0.5)._id
+    assert annotation0._id == TestAnnotation(value="test")._id
+    assert annotation1._id == TestAnnotation(value="test", score=0.9)._id
+    assert annotation2._id == TestAnnotation(value="test", score=0.5)._id
     # annotation id is different if the annotation is different (just in non-comparable fields)
     assert annotation0._id != annotation1._id and annotation0._id != annotation2._id
+
+    # assert that nothing changes when adding the annotation to a document
+    @dataclasses.dataclass
+    class TestDocument(TextDocument):
+        annotations: AnnotationList[TestAnnotation] = annotation_field(target="text")
+
+    id0 = annotation0._id
+    hash0 = hash(annotation0)
+    doc = TestDocument(text="test")
+    doc.annotations.append(annotation0)
+    assert annotation0._id == id0
+    assert hash(annotation0) == hash0
 
 
 def test_revert_annotation_graph():

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,5 +1,6 @@
 import dataclasses
 import re
+from typing import Optional
 
 import pytest
 
@@ -562,6 +563,28 @@ def test_annotation_list_targets():
         str(excinfo.value)
         == "The annotation layer has more or less than one target layer: ['entities1', 'entities2']"
     )
+
+
+def test_annotation_compare():
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class MyAnnotation(Annotation):
+        value: str
+        # Note that the score field is marked as not comparable
+        score: Optional[float] = dataclasses.field(compare=False, default=None)
+
+    annotation0 = MyAnnotation(value="test")
+    annotation1 = MyAnnotation(value="test", score=0.9)
+    annotation2 = MyAnnotation(value="test", score=0.5)
+
+    assert hash(annotation0) == hash(annotation1) == hash(annotation2)
+    assert annotation0 == annotation1 and annotation0 == annotation2
+
+    # annotation id is equal if the annotation is the same
+    assert annotation0._id == MyAnnotation(value="test")._id
+    assert annotation1._id == MyAnnotation(value="test", score=0.9)._id
+    assert annotation2._id == MyAnnotation(value="test", score=0.5)._id
+    # annotation id is different if the annotation is different (just in non-comparable fields)
+    assert annotation0._id != annotation1._id and annotation0._id != annotation2._id
 
 
 def test_revert_annotation_graph():


### PR DESCRIPTION
This PR
 - implements the property `Annotation.non_comparison_fields_and_values`,
 - modifies the property `Annotation._id` to include this, and
 - adds tests.

By including the non-comparison fields into the id property this avoids de-duplication issues when two annotations differ only in such a field (e.g. a prediction `score`). If they would not be included, one of the annotations would be removed.

This means that it can happen that `hash(annotation1) == hash(annotation1)`, but `annotation1._id != annotation2`. However, this follows the semantics of `dataclasses` with non-comparison fields and the `id()` method, e.g. this holds:

```python
@dataclasses.dataclass(frozen=True)
class A:
    x: int = dataclasses.field(compare=False)

a = A(x=0)
b = A(x=1)

assert a == b
assert hash(a) == hash(b)
# the id is different
assert id(a) != id(b)
```

Note: This is a breaking change because documents that were serialized before this PR are not loadable afterwards. 