### PR TITLE
implement `Document.add_all_annotations_from_other`

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -682,7 +682,7 @@ class Document(Mapping[str, Any]):
                 old_annotation._id -> new_annotation is present in the mapping for a certain field,
                 the new_annotation will be used anywhere where the old_annotation would have been
                 referenced. This propagates along the annotation graph and can be useful if some
-                annotations are modified, but all dependent relations should be kept intact e.g.
+                annotations are modified, but all dependent annotations should be kept intact e.g.
                 when converting a text-based document to token-based (or the other way around):
 
                 ```

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -681,9 +681,9 @@ class Document(Mapping[str, Any]):
                 no annotations will be added from the other document. Second, if a certain mapping
                 old_annotation._id -> new_annotation is present in the mapping for a certain field,
                 the new_annotation will be used anywhere where the old_annotation would have been
-                referenced. This can be useful if some annotations are modified, but all dependent
-                relations should be kept intact e.g. when converting a token-based document to text-based
-                or the other way around:
+                referenced. This propagates along the annotation graph and can be useful if some
+                annotations are modified, but all dependent relations should be kept intact e.g.
+                when converting a text-based document to token-based (or the other way around):
 
                 ```
                 @dataclasses.dataclass(frozen=True)

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -728,16 +728,20 @@ class Document(Mapping[str, Any]):
         """
 
         annotation_store: Dict[str, Dict[int, Annotation]] = defaultdict(dict)
+        named_annotation_fields = {field.name: field for field in self.annotation_fields()}
         if override_annotation_mapping is not None:
             for field_name, mapping in override_annotation_mapping.items():
+                if field_name not in named_annotation_fields:
+                    raise ValueError(
+                        f'Field "{field_name}" is not an annotation field of {type(self).__name__}, but keys in '
+                        f"override_annotation_mapping must be annotation field names."
+                    )
                 annotation_store[field_name].update(mapping)
         else:
             override_annotation_mapping = dict()
 
         fields_todo = ["_artificial_root"]
         fields_done = set()
-        # get the named annotation fields here to avoid re-computing them in the loop
-        named_annotation_fields = {field.name: field for field in self.annotation_fields()}
         reverted_annotation_graph = _revert_annotation_graph(self._annotation_graph)
         while fields_todo:
             field_name = fields_todo.pop(0)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -628,6 +628,19 @@ def test_extend_from_other_full_copy(text_document):
     assert text_document.asdict() == doc_new.asdict()
 
 
+def test_extend_from_other_wrong_override_annotation_mapping(text_document):
+    new_doc = type(text_document)(text="Hello World!")
+    with pytest.raises(ValueError) as excinfo:
+        new_doc.add_all_annotations_from_other(
+            text_document, override_annotation_mapping={"text": {}}
+        )
+    assert (
+        str(excinfo.value)
+        == 'Field "text" is not an annotation field of TextBasedDocumentWithEntitiesRelationsAndRelationAttributes, '
+           'but keys in override_annotation_mapping must be annotation field names.'
+    )
+
+
 def test_extend_from_other_override(text_document):
     @dataclasses.dataclass
     class TestDocument2(TokenBasedDocument):
@@ -646,7 +659,7 @@ def test_extend_from_other_override(text_document):
     # create annotation mapping
     e1 = text_document.entities1[0]
     e2 = text_document.entities2[0]
-    annotation_mapping = {"entities1": {e1._id: e1_new}, "entities2": {e2._id: e2_new}}
+    annotation_mapping = {"entities1": {e1._id: e1_new}, "entities2": {e2._id: e2_new}, "text": {}}
     # add new entities ...
     token_document.entities1.append(e1_new)
     token_document.entities2.append(e2_new)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -637,7 +637,7 @@ def test_extend_from_other_wrong_override_annotation_mapping(text_document):
     assert (
         str(excinfo.value)
         == 'Field "text" is not an annotation field of TextBasedDocumentWithEntitiesRelationsAndRelationAttributes, '
-           'but keys in override_annotation_mapping must be annotation field names.'
+        "but keys in override_annotation_mapping must be annotation field names."
     )
 
 
@@ -659,7 +659,7 @@ def test_extend_from_other_override(text_document):
     # create annotation mapping
     e1 = text_document.entities1[0]
     e2 = text_document.entities2[0]
-    annotation_mapping = {"entities1": {e1._id: e1_new}, "entities2": {e2._id: e2_new}, "text": {}}
+    annotation_mapping = {"entities1": {e1._id: e1_new}, "entities2": {e2._id: e2_new}}
     # add new entities ...
     token_document.entities1.append(e1_new)
     token_document.entities2.append(e2_new)


### PR DESCRIPTION
This PR implements `Document.add_all_annotations_from_other` which allows to add all annotations from another document. 

Furthermore, it has an optional parameter `override_annotation_mapping` which should be a mapping from annotation field names to mappings from annotation IDs to annotations. The effects are two-fold. First, adding any annotation field name as key has the effect that the field is expected to be already handled and no annotations will be added from the other document. Second, if an entry `old_annotation._id` -> `new_annotation` is present in the mapping for a certain field, the `new_annotation` will be used anywhere where the `old_annotation` would have been referenced. This propagates along the annotation graph and can be useful if some annotations are modified, but all dependent annotations should be kept intact e.g. when converting a text-based document to token-based (or the other way around):

```python
@dataclasses.dataclass(frozen=True)
class Attribute(Annotation):
    ref: Annotation
    value: str

@dataclasses.dataclass
class TextBasedDocumentWithEntitiesRelationsAndRelationAttributes(TextBasedDocument):
    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
    relation_attributes: AnnotationList[Attribute] = annotation_field(target="relations")

@dataclasses.dataclass
class TokenBasedDocumentWithEntitiesRelationsAndRelationAttributes(TokenBasedDocument):
    entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
    relation_attributes: AnnotationList[Attribute] = annotation_field(target="relations")


doc_text = TextBasedDocumentWithEntitiesRelationsAndRelationAttributes(text="Hello World!")
e1_text = LabeledSpan(0, 5, "word1")
e2_text = LabeledSpan(6, 11, "word2")
doc_text.entities.extend([e1, e2])
r1_text = BinaryRelation(e1_text, e2_text, "relation1")
doc_text.relations.append(r1_text)
doc_text.relation_attributes.append(Attribute(r1_text, "attribute1"))

doc_tokens = TokenBasedDocumentWithEntitiesRelationsAndRelationAttributes(
    tokens=("Hello", "World", "!")
)
e1_tokens = LabeledSpan(0, 1, "word1")
e2_tokens = LabeledSpan(1, 2, "word2")
doc_tokens.entities.extend([e1_tokens, e2_tokens])
doc_tokens.add_all_annotations_from_other(
    other=doc_text,
    override_annotation_mapping={"entities": {e1_text._id: e1_tokens, e2_text._id: e2_tokens}},
)
# Note that the relation and attribute are still present, but now refer to the new entities
# and new relation, respectively.
```