### PR TITLE
implement DocumentMetric and F1Metric

### DIFF
--- a/src/pytorch_ie/core/__init__.py
+++ b/src/pytorch_ie/core/__init__.py
@@ -1,3 +1,4 @@
 from .document import Annotation, AnnotationList, Document, annotation_field
+from .metric import DocumentMetric
 from .model import PyTorchIEModel
 from .taskmodule import TaskEncoding, TaskModule

--- a/src/pytorch_ie/core/metric.py
+++ b/src/pytorch_ie/core/metric.py
@@ -15,7 +15,6 @@ class DocumentMetric(ABC, Generic[T]):
     @abstractmethod
     def reset(self) -> None:
         """Any reset logic that needs to be performed before the metric is called again."""
-        ...
 
     def __call__(
         self,
@@ -61,9 +60,7 @@ class DocumentMetric(ABC, Generic[T]):
     @abstractmethod
     def _update(self, document: Document) -> None:
         """This method is called to update the metric with the new document."""
-        ...
 
     @abstractmethod
     def _compute(self) -> T:
         """This method is called to get the metric values."""
-        ...

--- a/src/pytorch_ie/core/metric.py
+++ b/src/pytorch_ie/core/metric.py
@@ -1,0 +1,69 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Generic, Iterable, TypeVar, Union
+
+from pytorch_ie.core.document import Document
+
+T = TypeVar("T")
+
+
+class DocumentMetric(ABC, Generic[T]):
+    """This defines the interface for a document metric."""
+
+    def __init__(self):
+        self.reset()
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Any reset logic that needs to be performed before the metric is called again."""
+        ...
+
+    def __call__(
+        self,
+        document_or_collection: Union[Iterable[Document], Document, Dict[str, Iterable[Document]]],
+    ) -> Union[Dict[str, T], T]:
+        """This method is called to update the metric with a document or collection of documents.
+
+        If a collection is passed, the metric is also computed and the result is returned. If the
+        collection is a dictionary, the metric is computed for each split and the result is
+        returned as a dictionary.
+        """
+        if isinstance(document_or_collection, Document):
+            # do not reset here to allow for multiple calls
+            self._update(document_or_collection)
+            return self.compute(reset=False)
+        elif isinstance(document_or_collection, dict):
+            result: Dict[str, T] = {}
+            for split_name, split in document_or_collection.items():
+                self.reset()
+                split_values: T = self(split)  # type: ignore
+                result[split_name] = split_values
+            return result
+        elif isinstance(document_or_collection, Iterable):
+            for doc in document_or_collection:
+                if not isinstance(doc, Document):
+                    raise Exception(
+                        f"document_or_collection contains an object that is not a document: {type(doc)}"
+                    )
+                self._update(doc)
+            # do not reset here to allow for multiple calls
+            return self.compute(reset=False)
+        else:
+            raise Exception(
+                f"document_or_collection has unknown type: {type(document_or_collection)}"
+            )
+
+    def compute(self, reset: bool = True) -> T:
+        metric_values = self._compute()
+        if reset:
+            self.reset()
+        return metric_values
+
+    @abstractmethod
+    def _update(self, document: Document) -> None:
+        """This method is called to update the metric with the new document."""
+        ...
+
+    @abstractmethod
+    def _compute(self) -> T:
+        """This method is called to get the metric values."""
+        ...

--- a/src/pytorch_ie/core/metric.py
+++ b/src/pytorch_ie/core/metric.py
@@ -40,14 +40,14 @@ class DocumentMetric(ABC, Generic[T]):
         elif isinstance(document_or_collection, Iterable):
             for doc in document_or_collection:
                 if not isinstance(doc, Document):
-                    raise Exception(
+                    raise TypeError(
                         f"document_or_collection contains an object that is not a document: {type(doc)}"
                     )
                 self._update(doc)
             # do not reset here to allow for multiple calls
             return self.compute(reset=False)
         else:
-            raise Exception(
+            raise TypeError(
                 f"document_or_collection has unknown type: {type(document_or_collection)}"
             )
 

--- a/src/pytorch_ie/metrics/__init__.py
+++ b/src/pytorch_ie/metrics/__init__.py
@@ -1,0 +1,3 @@
+from .f1 import F1Metric
+
+__all__ = ["F1Metric"]

--- a/src/pytorch_ie/metrics/f1.py
+++ b/src/pytorch_ie/metrics/f1.py
@@ -1,0 +1,131 @@
+import json
+import logging
+from collections import defaultdict
+from functools import partial
+from typing import Callable, Collection, Dict, Hashable, List, Optional, Set, Tuple
+
+import pandas as pd
+
+from pytorch_ie.core import Annotation, Document, DocumentMetric
+
+logger = logging.getLogger(__name__)
+
+
+def eval_counts_for_layer(
+    document: Document,
+    layer: str,
+    annotation_filter: Optional[Callable[[Annotation], bool]] = None,
+    annotation_mapper: Optional[Callable[[Annotation], Hashable]] = None,
+) -> Tuple[int, int, int]:
+    annotation_filter = annotation_filter or (lambda ann: True)
+    annotation_mapper = annotation_mapper or (lambda ann: ann)
+    predicted_annotations = {
+        annotation_mapper(ann) for ann in document[layer].predictions if annotation_filter(ann)
+    }
+    gold_annotations = {
+        annotation_mapper(ann) for ann in document[layer] if annotation_filter(ann)
+    }
+    tp = len([ann for ann in predicted_annotations & gold_annotations])
+    fn = len([ann for ann in gold_annotations - predicted_annotations])
+    fp = len([ann for ann in predicted_annotations - gold_annotations])
+    return tp, fp, fn
+
+
+def _remove_annotation_fields(ann: Annotation, exclude_annotation_fields: Set[str]):
+    return json.dumps(
+        {k: v for k, v in ann.asdict().items() if k not in exclude_annotation_fields},  # type: ignore
+        sort_keys=True,
+    )
+
+
+def has_one_of_the_labels(ann: Annotation, label_field: str, labels: Collection[str]) -> bool:
+    return getattr(ann, label_field) in labels
+
+
+def has_this_label(ann: Annotation, label_field: str, label: str) -> bool:
+    return getattr(ann, label_field) == label
+
+
+class F1Metric(DocumentMetric):
+    def __init__(
+        self,
+        layer: str,
+        label_field: Optional[str] = None,
+        labels: Optional[Collection[str]] = None,
+        exclude_annotation_fields: Optional[List[str]] = None,
+        show_as_markdown: bool = False,
+    ):
+        super().__init__()
+        self.layer = layer
+        self.label_field = label_field
+        self.show_as_markdown = show_as_markdown
+
+        self.labels = set(labels or [])
+        assert (
+            "MICRO" not in self.labels and "MACRO" not in self.labels
+        ), "labels cannot contain 'MICRO' or 'MACRO' because they are used to capture aggregated metrics"
+        if self.label_field is None:
+            assert (
+                len(self.labels) == 0
+            ), "can not calculate metrics per label without a provided label_field"
+
+        self.annotation_mapper: Optional[Callable[[Annotation], Hashable]] = None
+        if exclude_annotation_fields is not None:
+            exclude_annotation_fields.append("_id")
+            self.annotation_mapper = partial(
+                _remove_annotation_fields, exclude_annotation_fields=set(exclude_annotation_fields)
+            )
+
+    def reset(self):
+        self.counts = defaultdict(lambda: (0, 0, 0))
+
+    def add_counts(self, counts: Tuple[int, int, int], label: str):
+        self.counts[label] = (
+            self.counts[label][0] + counts[0],
+            self.counts[label][1] + counts[1],
+            self.counts[label][2] + counts[2],
+        )
+
+    def _update(self, document: Document):
+        new_counts = eval_counts_for_layer(
+            document=document,
+            layer=self.layer,
+            annotation_filter=partial(
+                has_one_of_the_labels, label_field=self.label_field, labels=self.labels
+            )
+            if self.label_field is not None
+            else None,
+            annotation_mapper=self.annotation_mapper,
+        )
+        self.add_counts(new_counts, label="MICRO")
+        for label in self.labels:
+            new_counts = eval_counts_for_layer(
+                document=document,
+                layer=self.layer,
+                annotation_filter=partial(
+                    has_this_label, label_field=self.label_field, label=label
+                ),
+                annotation_mapper=self.annotation_mapper,
+            )
+            self.add_counts(new_counts, label=label)
+
+    def _compute(self) -> Dict[str, Dict[str, float]]:
+        res = dict()
+        if len(self.labels) > 0:
+            res["MACRO"] = {"f1": 0.0, "p": 0.0, "r": 0.0}
+        for label, counts in self.counts.items():
+            tp, fp, fn = counts
+            if tp == 0:
+                p, r, f1 = 0.0, 0.0, 0.0
+            else:
+                p = tp / (tp + fp)
+                r = tp / (tp + fn)
+                f1 = 2 * p * r / (p + r)
+            res[label] = {"f1": f1, "p": p, "r": r}
+            if label in self.labels:
+                res["MACRO"]["f1"] += f1 / len(self.labels)
+                res["MACRO"]["p"] += p / len(self.labels)
+                res["MACRO"]["r"] += r / len(self.labels)
+        if self.show_as_markdown:
+            logger.info(f"\n{self.layer}:\n{pd.DataFrame(res).round(3).T.to_markdown()}")
+        return res

--- a/src/pytorch_ie/metrics/f1.py
+++ b/src/pytorch_ie/metrics/f1.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections import defaultdict
 from functools import partial
-from typing import Callable, Collection, Dict, Hashable, List, Optional, Set, Tuple
+from typing import Callable, Collection, Dict, Hashable, Optional, Set, Tuple
 
 import pandas as pd
 
@@ -52,7 +52,6 @@ class F1Metric(DocumentMetric):
         layer: str,
         label_field: Optional[str] = None,
         labels: Optional[Collection[str]] = None,
-        exclude_annotation_fields: Optional[List[str]] = None,
         show_as_markdown: bool = False,
     ):
         super().__init__()
@@ -68,13 +67,6 @@ class F1Metric(DocumentMetric):
             assert (
                 len(self.labels) == 0
             ), "can not calculate metrics per label without a provided label_field"
-
-        self.annotation_mapper: Optional[Callable[[Annotation], Hashable]] = None
-        if exclude_annotation_fields is not None:
-            exclude_annotation_fields.append("_id")
-            self.annotation_mapper = partial(
-                _remove_annotation_fields, exclude_annotation_fields=set(exclude_annotation_fields)
-            )
 
     def reset(self):
         self.counts = defaultdict(lambda: (0, 0, 0))
@@ -95,7 +87,6 @@ class F1Metric(DocumentMetric):
             )
             if self.label_field is not None
             else None,
-            annotation_mapper=self.annotation_mapper,
         )
         self.add_counts(new_counts, label="MICRO")
         for label in self.labels:
@@ -105,7 +96,6 @@ class F1Metric(DocumentMetric):
                 annotation_filter=partial(
                     has_this_label, label_field=self.label_field, label=label
                 ),
-                annotation_mapper=self.annotation_mapper,
             )
             self.add_counts(new_counts, label=label)
 

--- a/src/pytorch_ie/metrics/f1.py
+++ b/src/pytorch_ie/metrics/f1.py
@@ -1,8 +1,7 @@
-import json
 import logging
 from collections import defaultdict
 from functools import partial
-from typing import Callable, Collection, Dict, Hashable, Optional, Set, Tuple
+from typing import Callable, Collection, Dict, Hashable, Optional, Tuple
 
 import pandas as pd
 
@@ -55,12 +54,12 @@ class F1Metric(DocumentMetric):
         layer: str,
         labels: Optional[Collection[str]] = None,
         label_field: str = "label",
-        # show_as_markdown: bool = False,
+        show_as_markdown: bool = False,
     ):
         super().__init__()
         self.layer = layer
         self.label_field = label_field
-        # self.show_as_markdown = show_as_markdown
+        self.show_as_markdown = show_as_markdown
 
         self.per_label = labels is not None
         self.labels = labels or []
@@ -120,6 +119,6 @@ class F1Metric(DocumentMetric):
                 res["MACRO"]["f1"] += f1 / len(self.labels)
                 res["MACRO"]["p"] += p / len(self.labels)
                 res["MACRO"]["r"] += r / len(self.labels)
-        # if self.show_as_markdown:
-        #    logger.info(f"\n{self.layer}:\n{pd.DataFrame(res).round(3).T.to_markdown()}")
+        if self.show_as_markdown:
+            logger.info(f"\n{self.layer}:\n{pd.DataFrame(res).round(3).T.to_markdown()}")
         return res

--- a/src/pytorch_ie/metrics/f1.py
+++ b/src/pytorch_ie/metrics/f1.py
@@ -31,13 +31,6 @@ def eval_counts_for_layer(
     return tp, fp, fn
 
 
-def _remove_annotation_fields(ann: Annotation, exclude_annotation_fields: Set[str]):
-    return json.dumps(
-        {k: v for k, v in ann.asdict().items() if k not in exclude_annotation_fields},  # type: ignore
-        sort_keys=True,
-    )
-
-
 def has_one_of_the_labels(ann: Annotation, label_field: str, labels: Collection[str]) -> bool:
     return getattr(ann, label_field) in labels
 

--- a/src/pytorch_ie/metrics/f1.py
+++ b/src/pytorch_ie/metrics/f1.py
@@ -55,12 +55,12 @@ class F1Metric(DocumentMetric):
         layer: str,
         labels: Optional[Collection[str]] = None,
         label_field: str = "label",
-        show_as_markdown: bool = False,
+        # show_as_markdown: bool = False,
     ):
         super().__init__()
         self.layer = layer
         self.label_field = label_field
-        self.show_as_markdown = show_as_markdown
+        # self.show_as_markdown = show_as_markdown
 
         self.per_label = labels is not None
         self.labels = labels or []
@@ -120,6 +120,6 @@ class F1Metric(DocumentMetric):
                 res["MACRO"]["f1"] += f1 / len(self.labels)
                 res["MACRO"]["p"] += p / len(self.labels)
                 res["MACRO"]["r"] += r / len(self.labels)
-        if self.show_as_markdown:
-            logger.info(f"\n{self.layer}:\n{pd.DataFrame(res).round(3).T.to_markdown()}")
+        # if self.show_as_markdown:
+        #    logger.info(f"\n{self.layer}:\n{pd.DataFrame(res).round(3).T.to_markdown()}")
         return res

--- a/src/pytorch_ie/metrics/f1.py
+++ b/src/pytorch_ie/metrics/f1.py
@@ -47,6 +47,16 @@ def has_this_label(ann: Annotation, label_field: str, label: str) -> bool:
 
 
 class F1Metric(DocumentMetric):
+    """Computes the (micro aggregated) F1 score for a given layer. If labels are provided,
+    it also computes the F1 score for each label separately and the macro F1 score.
+
+    Args:
+        layer: The layer to compute the F1 score for.
+        labels: If provided, calculate F1 score for each label.
+        label_field: The field to use for the label. Defaults to "label".
+        show_as_markdown: If True, logs the F1 score as markdown on the console when calling compute().
+    """
+
     def __init__(
         self,
         layer: str,

--- a/tests/core/test_metric.py
+++ b/tests/core/test_metric.py
@@ -5,7 +5,6 @@ import pytest
 
 from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.core import AnnotationList, Document, DocumentMetric, annotation_field
-from pytorch_ie.core.metric import T
 from pytorch_ie.documents import TextBasedDocument
 
 

--- a/tests/core/test_metric.py
+++ b/tests/core/test_metric.py
@@ -71,12 +71,32 @@ class Accuracy(DocumentMetric):
 
 def test_document_metric(documents):
     accuracy = Accuracy(layer="entities")
+    accuracy(documents[0])
+    assert accuracy.total == 3
+    assert accuracy.correct == 2
+    assert accuracy.compute() == 2 / 3
+    assert accuracy.total == 0
+    assert accuracy.correct == 0
+
+
+def test_document_metric_iterable(documents):
+    accuracy = Accuracy(layer="entities")
     accuracy(documents)
     assert accuracy.total == 5
     assert accuracy.correct == 3
     assert accuracy.compute() == 3 / 5
     assert accuracy.total == 0
     assert accuracy.correct == 0
+
+
+def test_document_metric_wrong_iterable():
+    accuracy = Accuracy(layer="entities")
+    with pytest.raises(TypeError) as excinfo:
+        accuracy([1, 2])
+    assert (
+        str(excinfo.value)
+        == "document_or_collection contains an object that is not a document: <class 'int'>"
+    )
 
 
 def test_document_metric_dict(documents):
@@ -87,3 +107,10 @@ def test_document_metric_dict(documents):
     assert result["train"] == 2 / 3
     assert result["test"] == 0.5
     assert result["val"] is None
+
+
+def test_document_metric_wrong_type():
+    accuracy = Accuracy(layer="entities")
+    with pytest.raises(TypeError) as excinfo:
+        accuracy(1)
+    assert str(excinfo.value) == "document_or_collection has unknown type: <class 'int'>"

--- a/tests/core/test_metric.py
+++ b/tests/core/test_metric.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from pytorch_ie.annotations import LabeledSpan
+from pytorch_ie.core import AnnotationList, Document, DocumentMetric, annotation_field
+from pytorch_ie.core.metric import T
+from pytorch_ie.documents import TextBasedDocument
+
+
+@pytest.fixture
+def documents():
+    @dataclass
+    class TextDocumentWithEntities(TextBasedDocument):
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+
+    # a test sentence with two entities
+    doc1 = TextDocumentWithEntities(
+        text="The quick brown fox jumps over the lazy dog.",
+    )
+    doc1.entities.append(LabeledSpan(start=4, end=19, label="animal"))
+    doc1.entities.append(LabeledSpan(start=35, end=43, label="animal"))
+    assert str(doc1.entities[0]) == "quick brown fox"
+    assert str(doc1.entities[1]) == "lazy dog"
+
+    # a second test sentence with a different text and a single entity (a company)
+    doc2 = TextDocumentWithEntities(text="Apple is a great company.")
+    doc2.entities.append(LabeledSpan(start=0, end=5, label="company"))
+    assert str(doc2.entities[0]) == "Apple"
+
+    documents = [doc1, doc2]
+
+    # add predictions
+    # correct
+    documents[0].entities.predictions.append(LabeledSpan(start=4, end=19, label="animal"))
+    # correct, but duplicate, this should not be counted
+    documents[0].entities.predictions.append(LabeledSpan(start=4, end=19, label="animal"))
+    # correct
+    documents[0].entities.predictions.append(LabeledSpan(start=35, end=43, label="animal"))
+    # wrong label
+    documents[0].entities.predictions.append(LabeledSpan(start=35, end=43, label="cat"))
+    # correct
+    documents[1].entities.predictions.append(LabeledSpan(start=0, end=5, label="company"))
+    # wrong span
+    documents[1].entities.predictions.append(LabeledSpan(start=10, end=15, label="company"))
+
+    return documents
+
+
+class Accuracy(DocumentMetric):
+    def __init__(self, layer: str):
+        super().__init__()
+        self.layer = layer
+
+    def reset(self) -> None:
+        self.total = 0
+        self.correct = 0
+
+    def _update(self, document: Document) -> None:
+        layer = document[self.layer]
+        predictions = layer.predictions
+        self.total += len(set(predictions))
+        self.correct += len(set(layer) & set(predictions))
+
+    def _compute(self) -> Optional[float]:
+        if self.total == 0:
+            return None
+        return self.correct / self.total
+
+
+def test_document_metric(documents):
+    accuracy = Accuracy(layer="entities")
+    accuracy(documents)
+    assert accuracy.total == 5
+    assert accuracy.correct == 3
+    assert accuracy.compute() == 3 / 5
+    assert accuracy.total == 0
+    assert accuracy.correct == 0
+
+
+def test_document_metric_dict(documents):
+    dummy_dataset_dict = {"train": [documents[0]], "val": [], "test": [documents[1]]}
+    accuracy = Accuracy(layer="entities")
+    result = accuracy(dummy_dataset_dict)
+
+    assert result["train"] == 2 / 3
+    assert result["test"] == 0.5
+    assert result["val"] is None

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -47,7 +47,7 @@ def documents():
     return documents
 
 
-def test_document_metric(documents):
+def test_f1(documents):
     metric = F1Metric(layer="entities")
     metric(documents)
     # tp, fp, fn for micro
@@ -55,7 +55,7 @@ def test_document_metric(documents):
     assert metric.compute() == {"MICRO": {"f1": 0.7499999999999999, "p": 0.6, "r": 1.0}}
 
 
-def test_document_metric_per_label(documents):
+def test_f1_per_label(documents):
     metric = F1Metric(layer="entities", labels=["animal", "company", "cat"])
     metric(documents)
     # tp, fp, fn for micro and per label
@@ -74,16 +74,19 @@ def test_document_metric_per_label(documents):
     }
 
 
-def test_document_metric_per_label_no_labels(documents):
+def test_f1_per_label_no_labels(documents):
     with pytest.raises(ValueError) as excinfo:
         F1Metric(layer="entities", labels=[])
     assert str(excinfo.value) == "labels cannot be empty"
 
 
-def test_document_metric_dict(documents):
-    dummy_dataset_dict = {"train": [documents[0]], "val": [], "test": [documents[1]]}
-    metric = F1Metric(layer="entities")
-    result = metric(dummy_dataset_dict)
+def test_f1_per_label_not_allowed():
+    with pytest.raises(ValueError) as excinfo:
+        F1Metric(layer="entities", labels=["animal", "MICRO"])
+    assert (
+        str(excinfo.value)
+        == "labels cannot contain 'MICRO' or 'MACRO' because they are used to capture aggregated metrics"
+    )
 
     assert result == {
         "train": {"MICRO": {"f1": 0.8, "p": 0.6666666666666666, "r": 1.0}},

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -74,6 +74,12 @@ def test_document_metric_per_label(documents):
     }
 
 
+def test_document_metric_per_label_no_labels(documents):
+    with pytest.raises(ValueError) as excinfo:
+        F1Metric(layer="entities", labels=[])
+    assert str(excinfo.value) == "labels cannot be empty"
+
+
 def test_document_metric_dict(documents):
     dummy_dataset_dict = {"train": [documents[0]], "val": [], "test": [documents[1]]}
     metric = F1Metric(layer="entities")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+
+import pytest
+
+from pytorch_ie.annotations import LabeledSpan
+from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.documents import TextBasedDocument
+from pytorch_ie.metrics.f1 import F1Metric
+
+
+@pytest.fixture
+def documents():
+    @dataclass
+    class TextDocumentWithEntities(TextBasedDocument):
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+
+    # a test sentence with two entities
+    doc1 = TextDocumentWithEntities(
+        text="The quick brown fox jumps over the lazy dog.",
+    )
+    doc1.entities.append(LabeledSpan(start=4, end=19, label="animal"))
+    doc1.entities.append(LabeledSpan(start=35, end=43, label="animal"))
+    assert str(doc1.entities[0]) == "quick brown fox"
+    assert str(doc1.entities[1]) == "lazy dog"
+
+    # a second test sentence with a different text and a single entity (a company)
+    doc2 = TextDocumentWithEntities(text="Apple is a great company.")
+    doc2.entities.append(LabeledSpan(start=0, end=5, label="company"))
+    assert str(doc2.entities[0]) == "Apple"
+
+    documents = [doc1, doc2]
+
+    # add predictions
+    # correct
+    documents[0].entities.predictions.append(LabeledSpan(start=4, end=19, label="animal"))
+    # correct, but duplicate, this should not be counted
+    documents[0].entities.predictions.append(LabeledSpan(start=4, end=19, label="animal"))
+    # correct
+    documents[0].entities.predictions.append(LabeledSpan(start=35, end=43, label="animal"))
+    # wrong label
+    documents[0].entities.predictions.append(LabeledSpan(start=35, end=43, label="cat"))
+    # correct
+    documents[1].entities.predictions.append(LabeledSpan(start=0, end=5, label="company"))
+    # wrong span
+    documents[1].entities.predictions.append(LabeledSpan(start=10, end=15, label="company"))
+
+    return documents
+
+
+def test_document_metric(documents):
+    metric = F1Metric(layer="entities")
+    metric(documents)
+    # tp, fp, fn for micro
+    assert dict(metric.counts) == {"MICRO": (3, 2, 0)}
+    assert metric.compute() == {"MICRO": {"f1": 0.7499999999999999, "p": 0.6, "r": 1.0}}
+
+
+def test_document_metric_per_label(documents):
+    metric = F1Metric(layer="entities", label_field="label", labels=["animal", "company", "cat"])
+    metric(documents)
+    # tp, fp, fn for micro and per label
+    assert dict(metric.counts) == {
+        "MICRO": (3, 2, 0),
+        "cat": (0, 1, 0),
+        "company": (1, 1, 0),
+        "animal": (2, 0, 0),
+    }
+    assert metric.compute() == {
+        "MACRO": {"f1": 0.5555555555555556, "p": 0.5, "r": 0.6666666666666666},
+        "MICRO": {"f1": 0.7499999999999999, "p": 0.6, "r": 1.0},
+        "cat": {"f1": 0.0, "p": 0.0, "r": 0.0},
+        "company": {"f1": 0.6666666666666666, "p": 0.5, "r": 1.0},
+        "animal": {"f1": 1.0, "p": 1.0, "r": 1.0},
+    }
+
+
+def test_document_metric_dict(documents):
+    dummy_dataset_dict = {"train": [documents[0]], "val": [], "test": [documents[1]]}
+    metric = F1Metric(layer="entities")
+    result = metric(dummy_dataset_dict)
+
+    assert result == {
+        "train": {"MICRO": {"f1": 0.8, "p": 0.6666666666666666, "r": 1.0}},
+        "val": {},
+        "test": {"MICRO": {"f1": 0.6666666666666666, "p": 0.5, "r": 1.0}},
+    }

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -88,8 +88,22 @@ def test_f1_per_label_not_allowed():
         == "labels cannot contain 'MICRO' or 'MACRO' because they are used to capture aggregated metrics"
     )
 
-    assert result == {
-        "train": {"MICRO": {"f1": 0.8, "p": 0.6666666666666666, "r": 1.0}},
-        "val": {},
-        "test": {"MICRO": {"f1": 0.6666666666666666, "p": 0.5, "r": 1.0}},
-    }
+
+# def test_f1_show_as_markdown(documents, caplog):
+#    metric = F1Metric(layer="entities", labels=["animal", "company", "cat"], show_as_markdown=True)
+#    metric(documents)
+#    caplog.set_level(logging.INFO)
+#    caplog.clear()
+#    metric.compute()
+#    assert len(caplog.records) == 1
+#    assert (
+#        caplog.records[0].message == "\n"
+#        "entities:\n"
+#        "|         |    f1 |   p |     r |\n"
+#        "|:--------|------:|----:|------:|\n"
+#        "| MACRO   | 0.556 | 0.5 | 0.667 |\n"
+#        "| MICRO   | 0.75  | 0.6 | 1     |\n"
+#        "| animal  | 1     | 1   | 1     |\n"
+#        "| company | 0.667 | 0.5 | 1     |\n"
+#        "| cat     | 0     | 0   | 0     |"
+#    )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,7 +5,7 @@ import pytest
 from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.core import AnnotationList, annotation_field
 from pytorch_ie.documents import TextBasedDocument
-from pytorch_ie.metrics.f1 import F1Metric
+from pytorch_ie.metrics import F1Metric
 
 
 @pytest.fixture

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -56,7 +56,7 @@ def test_document_metric(documents):
 
 
 def test_document_metric_per_label(documents):
-    metric = F1Metric(layer="entities", label_field="label", labels=["animal", "company", "cat"])
+    metric = F1Metric(layer="entities", labels=["animal", "company", "cat"])
     metric(documents)
     # tp, fp, fn for micro and per label
     assert dict(metric.counts) == {


### PR DESCRIPTION
This PR implements the `DocumentMetric` interface with the following abstract methods:
 - `reset(self)`: Any reset logic that needs to be performed before the metric is called (again).
 - `_update(self, document: Document)`: This method is called to update the metric with the new document.
 - `_compute(self)`: This method should calculate and return the actual metric value(s).

An instance of such a class can be called with a single document, an iterable of documents, or a dict with values of the latter. In each case, the metric is updated with the documents and the computed metric value is returned. If the input was a dict, the values are calculated per dict value and a dict is returned again (i.e. it can be easily applied to a `DatasetDict`).

The PR also implements the `F1Metric` as a derivation of `DocumentMetric`.