### PR TITLE
Fix Document.add_all_annotations_from_other()

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -118,24 +118,6 @@ def _get_annotation_fields(fields: List[dataclasses.Field]) -> Set[dataclasses.F
     return {field for field in fields if typing.get_origin(field.type) is AnnotationList}
 
 
-def _revert_annotation_graph(annotation_graph: Dict[str, List[str]]) -> Dict[str, Set[str]]:
-    """Points from field names to the names of dependent annotation fields."""
-    reverted_annotation_graph = defaultdict(set)
-    all_target_names = set()
-    all_dependent_names = set()
-    for annotation_name, target_names in annotation_graph.items():
-        all_target_names.update(target_names)
-        all_dependent_names.add(annotation_name)
-        if annotation_name == "_artificial_root":
-            continue
-        for target_name in target_names:
-            reverted_annotation_graph[target_name].add(annotation_name)
-
-    reverted_annotation_graph["_artificial_root"] = all_target_names - all_dependent_names
-
-    return dict(reverted_annotation_graph)
-
-
 def annotation_field(
     target: Optional[str] = None,
     targets: Optional[List[str]] = None,

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -644,14 +644,14 @@ def text_document():
     return doc1
 
 
-def test_extend_from_other_full_copy(text_document):
+def test_document_extend_from_other_full_copy(text_document):
     doc_new = type(text_document)(text=text_document.text)
     doc_new.add_all_annotations_from_other(text_document)
 
     assert text_document.asdict() == doc_new.asdict()
 
 
-def test_extend_from_other_wrong_override_annotation_mapping(text_document):
+def test_document_extend_from_other_wrong_override_annotation_mapping(text_document):
     new_doc = type(text_document)(text="Hello World!")
     with pytest.raises(ValueError) as excinfo:
         new_doc.add_all_annotations_from_other(
@@ -664,7 +664,7 @@ def test_extend_from_other_wrong_override_annotation_mapping(text_document):
     )
 
 
-def test_extend_from_other_override(text_document):
+def test_document_extend_from_other_override(text_document):
     @dataclasses.dataclass
     class TestDocument2(TokenBasedDocument):
         entities1: AnnotationList[LabeledSpan] = annotation_field(target="tokens")

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -614,33 +614,6 @@ def test_annotation_compare():
     assert r1 == r2
 
 
-def test_revert_annotation_graph():
-    @dataclasses.dataclass
-    class TestDocument(TextDocument):
-        entities1: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        entities2: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations: AnnotationList[BinaryRelation] = annotation_field(
-            targets=["entities1", "entities2"]
-        )
-        labels: AnnotationList[Label] = annotation_field()
-
-    doc = TestDocument(text="test1")
-    annotation_graph = {k: set(v) for k, v in doc._annotation_graph.items()}
-    assert annotation_graph == {
-        "entities1": {"text"},
-        "entities2": {"text"},
-        "relations": {"entities1", "entities2"},
-        "_artificial_root": {"labels", "relations"},
-    }
-    reverted_graph = _revert_annotation_graph(doc._annotation_graph)
-    assert reverted_graph == {
-        "_artificial_root": {"text", "labels"},
-        "text": {"entities1", "entities2"},
-        "entities1": {"relations"},
-        "entities2": {"relations"},
-    }
-
-
 @dataclasses.dataclass(frozen=True)
 class Attribute(Annotation):
     ref: Annotation

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -6,12 +6,7 @@ import pytest
 
 from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, Span
 from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.core.document import (
-    Annotation,
-    Document,
-    _enumerate_dependencies,
-    _revert_annotation_graph,
-)
+from pytorch_ie.core.document import Annotation, Document, _enumerate_dependencies
 from pytorch_ie.documents import TextDocument, TokenBasedDocument
 
 


### PR DESCRIPTION
There might be edge cases where the previous algorithm did not work (e.g. a dependency graph with `a -> [b,c], c -> [b]`; here the old order would be `[a, b, c]`, but `b` requires `c` to be processed first). So, with this PR, `_enumerate_dependencies()` is used instead which is well tested. 