### PR TITLE
implement DocumentStatistics

### DIFF
--- a/src/pytorch_ie/core/__init__.py
+++ b/src/pytorch_ie/core/__init__.py
@@ -1,4 +1,5 @@
 from .document import Annotation, AnnotationList, Document, annotation_field
 from .metric import DocumentMetric
 from .model import PyTorchIEModel
+from .statistic import DocumentStatistic
 from .taskmodule import TaskEncoding, TaskModule

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -26,7 +26,7 @@ def unflatten_dict(d: Dict[Tuple[str, ...], Any]) -> Union[Dict[str, Any], Any]:
     ```python
     >>> d = {("a", "b", "c"): 1, ("a", "b", "d"): 2, ("a", "e"): 3}
     >>> unflatten_dict(d)
-    {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+    {'a': {'b': {'c': 1, 'd': 2}, 'e': 3}}
     ```
     """
     result: Dict[str, Any] = {}

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -1,0 +1,101 @@
+from abc import abstractmethod
+from collections import defaultdict
+from typing import Any, Dict, Generator, List, Tuple, Union
+
+from pytorch_ie.core.document import Document
+from pytorch_ie.core.metric import DocumentMetric
+
+
+def _flatten_dict_gen(d, parent_key: Tuple[str, ...] = ()) -> Generator:
+    for k, v in d.items():
+        new_key = parent_key + (k,)
+        if isinstance(v, dict):
+            yield from dict(_flatten_dict_gen(v, new_key)).items()
+        else:
+            yield new_key, v
+
+
+def flatten_dict(d: Dict[str, Any]) -> Dict[Tuple[str, ...], Any]:
+    return dict(_flatten_dict_gen(d))
+
+
+def unflatten_dict(d: Dict[Tuple[str, ...], Any]) -> Union[Dict[str, Any], Any]:
+    """Unflattens a dictionary with nested keys.
+
+    Example:
+    ```python
+    >>> d = {("a", "b", "c"): 1, ("a", "b", "d"): 2, ("a", "e"): 3}
+    >>> unflatten_dict(d)
+    {"a": {"b": {"c": 1, "d": 2}, "e": 3}}
+    ```
+    """
+    result: Dict[str, Any] = {}
+    for k, v in d.items():
+        if len(k) == 0:
+            if len(result) > 1:
+                raise ValueError("Cannot unflatten dictionary with multiple root keys.")
+            return v
+        current = result
+        for key in k[:-1]:
+            current = current.setdefault(key, {})
+        current[k[-1]] = v
+    return result
+
+
+class DocumentStatistic(DocumentMetric):
+    """A special type of metric that collects statistics from a document.
+
+    Usage:
+
+    ```python
+    from transformers import AutoTokenizer
+    from pytorch_ie import DatasetDict
+
+    class DocumentTokenCounter(DocumentStatistic):
+        def __init__(self, tokenizer_name_or_path: str, field: str, **kwargs):
+            super().__init__()
+            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path)
+            self.kwargs = kwargs
+            self.field = field
+
+        def _collect(self, doc: Document) -> int:
+            text = getattr(doc, self.field)
+            encodings = self.tokenizer(text, **self.kwargs)
+            tokens = encodings.tokens()
+            return len(tokens)
+
+    dataset = DatasetDict.load_dataset("pie/conll2003")
+    statistic = DocumentTokenCounter(tokenizer_name_or_path="bert-base-cased", field="text")
+    values = statistic(dataset)
+    ```
+    """
+
+    def reset(self) -> None:
+        self._values: List[Any] = []
+
+    @abstractmethod
+    def _collect(self, doc: Document) -> Any:
+        """Collect any values from a document."""
+
+    def _update(self, document: Document) -> None:
+        values = self._collect(document)
+        self._values.append(values)
+
+    def _compute(self) -> Any:
+        """We just integrate the values by creating lists for each leaf of the (nested)
+        dictionary."""
+        stats = defaultdict(list)
+        for metric_result in self._values:
+            if isinstance(metric_result, dict):
+                measure_result_flat = flatten_dict(metric_result)
+                for k, v in measure_result_flat.items():
+                    if isinstance(v, list):
+                        stats[k].extend(v)
+                    else:
+                        stats[k].append(v)
+            else:
+                if isinstance(metric_result, list):
+                    stats[()].extend(metric_result)
+                else:
+                    stats[()].append(metric_result)
+        return dict(stats)

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -48,8 +48,9 @@ class DocumentStatistic(DocumentMetric):
     ```python
     from transformers import AutoTokenizer
     from pytorch_ie import DatasetDict
+    from pytorch_ie.core import Document, DocumentStatistic
 
-    class DocumentTokenCounter(DocumentStatistic):
+    class TokenCountCollector(DocumentStatistic):
         def __init__(self, tokenizer_name_or_path: str, field: str, **kwargs):
             super().__init__()
             self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path)
@@ -63,8 +64,13 @@ class DocumentStatistic(DocumentMetric):
             return len(tokens)
 
     dataset = DatasetDict.load_dataset("pie/conll2003")
-    statistic = DocumentTokenCounter(tokenizer_name_or_path="bert-base-cased", field="text")
+    statistic = TokenCountCollector(tokenizer_name_or_path="bert-base-cased", field="text")
     values = statistic(dataset)
+    assert values == {
+        'train': [12, 4, 11, 34, 39, 43, 27, 50, 45, 43, ...],
+        'validation': [37, 11, 40, 43, 44, 27, 35, 40, 48, 43, ...],
+        'test': [33, 8, 15, 29, 30, 56, 31, 19, 21, 30, ...],
+    }
     ```
     """
 

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -89,17 +89,17 @@ class DocumentStatistic(DocumentMetric):
         """We just integrate the values by creating lists for each leaf of the (nested)
         dictionary."""
         stats = defaultdict(list)
-        for metric_result in self._values:
-            if isinstance(metric_result, dict):
-                measure_result_flat = flatten_dict(metric_result)
-                for k, v in measure_result_flat.items():
+        for collected_result in self._values:
+            if isinstance(collected_result, dict):
+                collected_result_flat = flatten_dict(collected_result)
+                for k, v in collected_result_flat.items():
                     if isinstance(v, list):
                         stats[k].extend(v)
                     else:
                         stats[k].append(v)
             else:
-                if isinstance(metric_result, list):
-                    stats[()].extend(metric_result)
+                if isinstance(collected_result, list):
+                    stats[()].extend(collected_result)
                 else:
-                    stats[()].append(metric_result)
+                    stats[()].append(collected_result)
         return unflatten_dict(dict(stats))

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -23,11 +23,9 @@ def unflatten_dict(d: Dict[Tuple[str, ...], Any]) -> Union[Dict[str, Any], Any]:
     """Unflattens a dictionary with nested keys.
 
     Example:
-    ```python
-    >>> d = {("a", "b", "c"): 1, ("a", "b", "d"): 2, ("a", "e"): 3}
-    >>> unflatten_dict(d)
-    {'a': {'b': {'c': 1, 'd': 2}, 'e': 3}}
-    ```
+        >>> d = {("a", "b", "c"): 1, ("a", "b", "d"): 2, ("a", "e"): 3}
+        >>> unflatten_dict(d)
+        {'a': {'b': {'c': 1, 'd': 2}, 'e': 3}}
     """
     result: Dict[str, Any] = {}
     for k, v in d.items():

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -98,4 +98,4 @@ class DocumentStatistic(DocumentMetric):
                     stats[()].extend(metric_result)
                 else:
                     stats[()].append(metric_result)
-        return dict(stats)
+        return unflatten_dict(dict(stats))

--- a/src/pytorch_ie/metrics/statistics.py
+++ b/src/pytorch_ie/metrics/statistics.py
@@ -6,7 +6,7 @@ from transformers import AutoTokenizer
 from pytorch_ie.core import Document, DocumentStatistic
 
 
-class DocumentTokenCounter(DocumentStatistic):
+class TokenCountCollector(DocumentStatistic):
     """Collects the token count of a field when tokenizing its content with a Huggingface tokenizer.
 
     The field should be a string.
@@ -25,7 +25,7 @@ class DocumentTokenCounter(DocumentStatistic):
         return len(tokens)
 
 
-class DocumentFieldLengthCounter(DocumentStatistic):
+class FieldLengthCollector(DocumentStatistic):
     """Collects the length of a field, e.g. to collect the number the characters in the input text.
 
     The field should be a list of sized elements.
@@ -40,7 +40,7 @@ class DocumentFieldLengthCounter(DocumentStatistic):
         return len(field_obj)
 
 
-class DocumentSubFieldLengthCounter(DocumentStatistic):
+class SubFieldLengthCollector(DocumentStatistic):
     """Collects the length of a subfield in a field, e.g. to collect the number of arguments of N-ary relations."""
 
     def __init__(self, field: str, subfield: str):
@@ -57,7 +57,7 @@ class DocumentSubFieldLengthCounter(DocumentStatistic):
         return lengths
 
 
-class DocumentSpanLengthCounter(DocumentStatistic):
+class LabeledSpanLengthCollector(DocumentStatistic):
     """Collects the length of spans in a field per label, e.g. to collect the length of entities per type.
 
     The field should be a list of elements with a label, a start and end attribute.
@@ -75,7 +75,7 @@ class DocumentSpanLengthCounter(DocumentStatistic):
         return dict(counts)
 
 
-class DummyCounter(DocumentStatistic):
+class DummyCollector(DocumentStatistic):
     """A dummy collector that always returns 1, e.g. to count the number of documents.
 
     Can be used to count the number of documents.
@@ -85,7 +85,7 @@ class DummyCounter(DocumentStatistic):
         return 1
 
 
-class LabelCounter(DocumentStatistic):
+class LabelCountCollector(DocumentStatistic):
     """Collects the number of field entries per label, e.g. to collect the number of entities per type.
 
     The field should be a list of elements with a label attribute.

--- a/src/pytorch_ie/metrics/statistics.py
+++ b/src/pytorch_ie/metrics/statistics.py
@@ -1,0 +1,106 @@
+from collections import defaultdict
+from typing import Dict, List
+
+from transformers import AutoTokenizer
+
+from pytorch_ie.core import Document, DocumentStatistic
+
+
+class DocumentTokenCounter(DocumentStatistic):
+    """Counts the number of tokens in a field by tokenizing it with a Huggingface tokenizer.
+
+    The field should be a string.
+    """
+
+    def __init__(self, tokenizer_name_or_path: str, field: str, **kwargs):
+        super().__init__()
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path)
+        self.kwargs = kwargs
+        self.field = field
+
+    def _collect(self, doc: Document) -> int:
+        text = getattr(doc, self.field)
+        encodings = self.tokenizer(text, **self.kwargs)
+        tokens = encodings.tokens()
+        return len(tokens)
+
+
+class DocumentFieldLengthCounter(DocumentStatistic):
+    """Counts the length of a field.
+
+    The field should be a list of sized elements.
+    """
+
+    def __init__(self, field: str):
+        super().__init__()
+        self.field = field
+
+    def _collect(self, doc: Document) -> int:
+        field_obj = getattr(doc, self.field)
+        return len(field_obj)
+
+
+class DocumentSubFieldLengthCounter(DocumentStatistic):
+    """Counts the length of a subfield in a field."""
+
+    def __init__(self, field: str, subfield: str):
+        super().__init__()
+        self.field = field
+        self.subfield = subfield
+
+    def _collect(self, doc: Document) -> List[int]:
+        field_obj = getattr(doc, self.field)
+        lengths = []
+        for entry in field_obj:
+            subfield_obj = getattr(entry, self.subfield)
+            lengths.append(len(subfield_obj))
+        return lengths
+
+
+class DocumentSpanLengthCounter(DocumentStatistic):
+    """Counts the length of spans in a field.
+
+    The field should be a list of elements with a label, a start and end attribute.
+    """
+
+    def __init__(self, field: str):
+        super().__init__()
+        self.field = field
+
+    def _collect(self, doc: Document) -> Dict[str, List[int]]:
+        field_obj = getattr(doc, self.field)
+        counts = defaultdict(list)
+        for elem in field_obj:
+            counts[elem.label].append(elem.end - elem.start)
+        return dict(counts)
+
+
+class DummyCounter(DocumentStatistic):
+    """A dummy counter that always returns 1.
+
+    Can be used to count the number of documents.
+    """
+
+    def _collect(self, doc: Document) -> int:
+        return 1
+
+
+class LabelCounter(DocumentStatistic):
+    """A counter that counts the number of labels in a field.
+
+    The field should be a list of elements with a label attribute.
+
+    Important: To make correct use of the result data, missing values need to be filled with 0, e.g.:
+        {("ORG",): [2, 3], ("LOC",): [2]} -> {("ORG",): [2, 3], ("LOC",): [2, 0]}
+    """
+
+    def __init__(self, field: str):
+        super().__init__()
+        self.field = field
+
+    def _collect(self, doc: Document) -> Dict[str, int]:
+        field_obj = getattr(doc, self.field)
+        counts: Dict[str, int] = defaultdict(lambda: 1)
+        for elem in field_obj:
+            counts[elem.label] += 1
+        return dict(counts)

--- a/src/pytorch_ie/metrics/statistics.py
+++ b/src/pytorch_ie/metrics/statistics.py
@@ -7,7 +7,7 @@ from pytorch_ie.core import Document, DocumentStatistic
 
 
 class DocumentTokenCounter(DocumentStatistic):
-    """Counts the number of tokens in a field by tokenizing it with a Huggingface tokenizer.
+    """Collects the token count of a field when tokenizing its content with a Huggingface tokenizer.
 
     The field should be a string.
     """
@@ -26,7 +26,7 @@ class DocumentTokenCounter(DocumentStatistic):
 
 
 class DocumentFieldLengthCounter(DocumentStatistic):
-    """Counts the length of a field.
+    """Collects the length of a field, e.g. to collect the number the characters in the input text.
 
     The field should be a list of sized elements.
     """
@@ -41,7 +41,7 @@ class DocumentFieldLengthCounter(DocumentStatistic):
 
 
 class DocumentSubFieldLengthCounter(DocumentStatistic):
-    """Counts the length of a subfield in a field."""
+    """Collects the length of a subfield in a field, e.g. to collect the number of arguments of N-ary relations."""
 
     def __init__(self, field: str, subfield: str):
         super().__init__()
@@ -58,7 +58,7 @@ class DocumentSubFieldLengthCounter(DocumentStatistic):
 
 
 class DocumentSpanLengthCounter(DocumentStatistic):
-    """Counts the length of spans in a field.
+    """Collects the length of spans in a field per label, e.g. to collect the length of entities per type.
 
     The field should be a list of elements with a label, a start and end attribute.
     """
@@ -76,7 +76,7 @@ class DocumentSpanLengthCounter(DocumentStatistic):
 
 
 class DummyCounter(DocumentStatistic):
-    """A dummy counter that always returns 1.
+    """A dummy collector that always returns 1, e.g. to count the number of documents.
 
     Can be used to count the number of documents.
     """
@@ -86,7 +86,7 @@ class DummyCounter(DocumentStatistic):
 
 
 class LabelCounter(DocumentStatistic):
-    """A counter that counts the number of labels in a field.
+    """Collects the number of field entries per label, e.g. to collect the number of entities per type.
 
     The field should be a list of elements with a label attribute.
 

--- a/tests/core/test_statistic.py
+++ b/tests/core/test_statistic.py
@@ -8,12 +8,12 @@ from pytorch_ie.core import AnnotationList, annotation_field
 from pytorch_ie.core.statistic import flatten_dict
 from pytorch_ie.documents import TextBasedDocument
 from pytorch_ie.metrics.statistics import (
-    DocumentFieldLengthCounter,
-    DocumentSpanLengthCounter,
-    DocumentSubFieldLengthCounter,
-    DocumentTokenCounter,
-    DummyCounter,
-    LabelCounter,
+    DummyCollector,
+    FieldLengthCollector,
+    LabelCountCollector,
+    LabeledSpanLengthCollector,
+    SubFieldLengthCollector,
+    TokenCountCollector,
 )
 from tests import FIXTURES_ROOT
 
@@ -31,7 +31,7 @@ def dataset():
 
 
 def test_prepare_data(dataset):
-    statistic = DummyCounter()
+    statistic = DummyCollector()
     values_nested = statistic(dataset)
     prepared_data = flatten_dict(values_nested)
     assert prepared_data == {
@@ -39,7 +39,7 @@ def test_prepare_data(dataset):
         ("test",): [1, 1, 1],
         ("validation",): [1, 1, 1],
     }
-    statistic = LabelCounter(field="entities")
+    statistic = LabelCountCollector(field="entities")
     values_nested = statistic(dataset)
     prepared_data = flatten_dict(values_nested)
     assert prepared_data == {
@@ -54,7 +54,7 @@ def test_prepare_data(dataset):
         ("validation", "MISC"): [2],
         ("validation", "PER"): [2],
     }
-    statistic = DocumentFieldLengthCounter(field="text")
+    statistic = FieldLengthCollector(field="text")
     values_nested = statistic(dataset)
     prepared_data = flatten_dict(values_nested)
     assert prepared_data == {
@@ -63,7 +63,7 @@ def test_prepare_data(dataset):
         ("validation",): [65, 17, 187],
     }
 
-    statistic = DocumentSpanLengthCounter(field="entities")
+    statistic = LabeledSpanLengthCollector(field="entities")
     values_nested = statistic(dataset)
     prepared_data = flatten_dict(values_nested)
     assert prepared_data == {
@@ -80,7 +80,7 @@ def test_prepare_data(dataset):
     }
 
     # this is not super useful, we just collect teh lengths of the labels, but it is enough to test the code
-    statistic = DocumentSubFieldLengthCounter(field="entities", subfield="label")
+    statistic = SubFieldLengthCollector(field="entities", subfield="label")
     values_nested = statistic(dataset)
     prepared_data = flatten_dict(values_nested)
     assert prepared_data == {
@@ -92,7 +92,7 @@ def test_prepare_data(dataset):
 
 @pytest.mark.slow
 def test_prepare_data_tokenize(dataset):
-    statistic = DocumentTokenCounter(
+    statistic = TokenCountCollector(
         field="text", tokenizer_name_or_path="bert-base-uncased", add_special_tokens=False
     )
     values_nested = statistic(dataset)

--- a/tests/core/test_statistic.py
+++ b/tests/core/test_statistic.py
@@ -34,14 +34,16 @@ def dataset():
 
 def test_prepare_data(dataset):
     statistic = DummyCounter()
-    prepared_data = statistic(dataset)
+    values_nested = statistic(dataset)
+    prepared_data = flatten_dict(values_nested)
     assert prepared_data == {
         ("train",): [1, 1, 1],
         ("test",): [1, 1, 1],
         ("validation",): [1, 1, 1],
     }
     statistic = LabelCounter(field="entities")
-    prepared_data = statistic(dataset)
+    values_nested = statistic(dataset)
+    prepared_data = flatten_dict(values_nested)
     assert prepared_data == {
         ("train", "ORG"): [2],
         ("train", "MISC"): [3],
@@ -55,7 +57,8 @@ def test_prepare_data(dataset):
         ("validation", "PER"): [2],
     }
     statistic = DocumentFieldLengthCounter(field="text")
-    prepared_data = statistic(dataset)
+    values_nested = statistic(dataset)
+    prepared_data = flatten_dict(values_nested)
     assert prepared_data == {
         ("train",): [48, 15, 19],
         ("test",): [57, 11, 40],
@@ -68,7 +71,8 @@ def test_prepare_data_tokenize(dataset):
     statistic = DocumentTokenCounter(
         field="text", tokenizer_name_or_path="bert-base-uncased", add_special_tokens=False
     )
-    prepared_data = statistic(dataset)
+    values_nested = statistic(dataset)
+    prepared_data = flatten_dict(values_nested)
     assert prepared_data == {
         ("train",): [9, 2, 6],
         ("test",): [12, 4, 12],

--- a/tests/core/test_statistic.py
+++ b/tests/core/test_statistic.py
@@ -1,0 +1,149 @@
+import dataclasses
+from collections import defaultdict
+from functools import partial
+from typing import Callable, Dict, List, Tuple, Union
+
+import pytest
+from typing_extensions import TypeAlias
+
+from pytorch_ie import DatasetDict
+from pytorch_ie.annotations import LabeledSpan
+from pytorch_ie.core import AnnotationList, Document, annotation_field
+from pytorch_ie.core.statistic import flatten_dict
+from pytorch_ie.documents import TextBasedDocument
+from pytorch_ie.metrics.statistics import (
+    DocumentFieldLengthCounter,
+    DocumentTokenCounter,
+    DummyCounter,
+    LabelCounter,
+)
+from tests import FIXTURES_ROOT
+
+
+@pytest.fixture
+def dataset():
+    @dataclasses.dataclass
+    class Conll2003Document(TextBasedDocument):
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+
+    return DatasetDict.from_json(
+        data_dir=FIXTURES_ROOT / "dataset_dict" / "conll2003_extract",
+        document_type=Conll2003Document,
+    )
+
+
+def test_prepare_data(dataset):
+    statistic = DummyCounter()
+    prepared_data = statistic(dataset)
+    assert prepared_data == {
+        ("train",): [1, 1, 1],
+        ("test",): [1, 1, 1],
+        ("validation",): [1, 1, 1],
+    }
+    statistic = LabelCounter(field="entities")
+    prepared_data = statistic(dataset)
+    assert prepared_data == {
+        ("train", "ORG"): [2],
+        ("train", "MISC"): [3],
+        ("train", "PER"): [2],
+        ("train", "LOC"): [2],
+        ("test", "LOC"): [2, 3],
+        ("test", "PER"): [2, 2],
+        ("validation", "ORG"): [2, 3],
+        ("validation", "LOC"): [2],
+        ("validation", "MISC"): [2],
+        ("validation", "PER"): [2],
+    }
+    statistic = DocumentFieldLengthCounter(field="text")
+    prepared_data = statistic(dataset)
+    assert prepared_data == {
+        ("train",): [48, 15, 19],
+        ("test",): [57, 11, 40],
+        ("validation",): [65, 17, 187],
+    }
+
+
+@pytest.mark.slow
+def test_prepare_data_tokenize(dataset):
+    statistic = DocumentTokenCounter(
+        field="text", tokenizer_name_or_path="bert-base-uncased", add_special_tokens=False
+    )
+    prepared_data = statistic(dataset)
+    assert prepared_data == {
+        ("train",): [9, 2, 6],
+        ("test",): [12, 4, 12],
+        ("validation",): [11, 6, 38],
+    }
+
+
+def label_counter(doc: Document, field: str) -> Dict[str, int]:
+    field_obj = getattr(doc, field)
+    counts: Dict[str, int] = defaultdict(lambda: 1)
+    for elem in field_obj:
+        counts[elem.label] += 1
+    return dict(counts)
+
+
+def document_field_length_collector(doc: Document, field: str) -> int:
+    field_obj = getattr(doc, field)
+    return len(field_obj)
+
+
+# The metric should return a single int or float or a list of such values ...
+BaseType: TypeAlias = Union[int, float]
+ResultTerminal: TypeAlias = Union[BaseType, List[BaseType]]
+# ... or such entries nested arbitrarily deep inside dictionaries.
+ResultDict: TypeAlias = Dict[str, Union[ResultTerminal, "ResultDict"]]
+
+
+def prepare_data(
+    dataset: DatasetDict,
+    metric: Callable[[Document], Union[ResultTerminal, ResultDict]],
+) -> Dict[Tuple[str, ...], List[BaseType]]:
+    stats = defaultdict(list)
+    for s_name, split in dataset.items():
+        for doc in split:
+            metric_result = metric(doc)
+            if isinstance(metric_result, dict):
+                metric_result_flat = flatten_dict(metric_result)
+                for k, v in metric_result_flat.items():
+                    if isinstance(v, list):
+                        stats[(s_name,) + k].extend(v)
+                    else:
+                        stats[(s_name,) + k].append(v)
+            else:
+                if isinstance(metric_result, list):
+                    stats[(s_name,)].extend(metric_result)
+                else:
+                    stats[(s_name,)].append(metric_result)
+    return dict(stats)
+
+
+def test_prepare_data_simple(dataset):
+    prepared_data = prepare_data(dataset=dataset, metric=lambda doc: 1)
+    assert prepared_data == {
+        ("train",): [1, 1, 1],
+        ("test",): [1, 1, 1],
+        ("validation",): [1, 1, 1],
+    }
+    prepared_data = prepare_data(dataset=dataset, metric=partial(label_counter, field="entities"))
+    assert prepared_data == {
+        ("train", "ORG"): [2],
+        ("train", "MISC"): [3],
+        ("train", "PER"): [2],
+        ("train", "LOC"): [2],
+        ("test", "LOC"): [2, 3],
+        ("test", "PER"): [2, 2],
+        ("validation", "ORG"): [2, 3],
+        ("validation", "LOC"): [2],
+        ("validation", "MISC"): [2],
+        ("validation", "PER"): [2],
+    }
+    prepared_data = prepare_data(
+        dataset=dataset, metric=partial(document_field_length_collector, field="text")
+    )
+    assert prepared_data == {
+        ("train",): [48, 15, 19],
+        ("test",): [57, 11, 40],
+        ("validation",): [65, 17, 187],
+    }

--- a/tests/core/test_statistic.py
+++ b/tests/core/test_statistic.py
@@ -1,18 +1,16 @@
 import dataclasses
-from collections import defaultdict
-from functools import partial
-from typing import Callable, Dict, List, Tuple, Union
 
 import pytest
-from typing_extensions import TypeAlias
 
 from pytorch_ie import DatasetDict
 from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.core import AnnotationList, Document, annotation_field
+from pytorch_ie.core import AnnotationList, annotation_field
 from pytorch_ie.core.statistic import flatten_dict
 from pytorch_ie.documents import TextBasedDocument
 from pytorch_ie.metrics.statistics import (
     DocumentFieldLengthCounter,
+    DocumentSpanLengthCounter,
+    DocumentSubFieldLengthCounter,
     DocumentTokenCounter,
     DummyCounter,
     LabelCounter,
@@ -65,6 +63,32 @@ def test_prepare_data(dataset):
         ("validation",): [65, 17, 187],
     }
 
+    statistic = DocumentSpanLengthCounter(field="entities")
+    values_nested = statistic(dataset)
+    prepared_data = flatten_dict(values_nested)
+    assert prepared_data == {
+        ("train", "ORG"): [2],
+        ("train", "MISC"): [6, 7],
+        ("train", "PER"): [15],
+        ("train", "LOC"): [8],
+        ("test", "LOC"): [5, 6, 20],
+        ("test", "PER"): [5, 11],
+        ("validation", "ORG"): [14, 14, 8],
+        ("validation", "LOC"): [6],
+        ("validation", "MISC"): [11],
+        ("validation", "PER"): [12],
+    }
+
+    # this is not super useful, we just collect teh lengths of the labels, but it is enough to test the code
+    statistic = DocumentSubFieldLengthCounter(field="entities", subfield="label")
+    values_nested = statistic(dataset)
+    prepared_data = flatten_dict(values_nested)
+    assert prepared_data == {
+        ("train",): [3, 4, 4, 3, 3],
+        ("test",): [3, 3, 3, 3, 3],
+        ("validation",): [3, 3, 4, 3, 3, 3],
+    }
+
 
 @pytest.mark.slow
 def test_prepare_data_tokenize(dataset):
@@ -77,77 +101,4 @@ def test_prepare_data_tokenize(dataset):
         ("train",): [9, 2, 6],
         ("test",): [12, 4, 12],
         ("validation",): [11, 6, 38],
-    }
-
-
-def label_counter(doc: Document, field: str) -> Dict[str, int]:
-    field_obj = getattr(doc, field)
-    counts: Dict[str, int] = defaultdict(lambda: 1)
-    for elem in field_obj:
-        counts[elem.label] += 1
-    return dict(counts)
-
-
-def document_field_length_collector(doc: Document, field: str) -> int:
-    field_obj = getattr(doc, field)
-    return len(field_obj)
-
-
-# The metric should return a single int or float or a list of such values ...
-BaseType: TypeAlias = Union[int, float]
-ResultTerminal: TypeAlias = Union[BaseType, List[BaseType]]
-# ... or such entries nested arbitrarily deep inside dictionaries.
-ResultDict: TypeAlias = Dict[str, Union[ResultTerminal, "ResultDict"]]
-
-
-def prepare_data(
-    dataset: DatasetDict,
-    metric: Callable[[Document], Union[ResultTerminal, ResultDict]],
-) -> Dict[Tuple[str, ...], List[BaseType]]:
-    stats = defaultdict(list)
-    for s_name, split in dataset.items():
-        for doc in split:
-            metric_result = metric(doc)
-            if isinstance(metric_result, dict):
-                metric_result_flat = flatten_dict(metric_result)
-                for k, v in metric_result_flat.items():
-                    if isinstance(v, list):
-                        stats[(s_name,) + k].extend(v)
-                    else:
-                        stats[(s_name,) + k].append(v)
-            else:
-                if isinstance(metric_result, list):
-                    stats[(s_name,)].extend(metric_result)
-                else:
-                    stats[(s_name,)].append(metric_result)
-    return dict(stats)
-
-
-def test_prepare_data_simple(dataset):
-    prepared_data = prepare_data(dataset=dataset, metric=lambda doc: 1)
-    assert prepared_data == {
-        ("train",): [1, 1, 1],
-        ("test",): [1, 1, 1],
-        ("validation",): [1, 1, 1],
-    }
-    prepared_data = prepare_data(dataset=dataset, metric=partial(label_counter, field="entities"))
-    assert prepared_data == {
-        ("train", "ORG"): [2],
-        ("train", "MISC"): [3],
-        ("train", "PER"): [2],
-        ("train", "LOC"): [2],
-        ("test", "LOC"): [2, 3],
-        ("test", "PER"): [2, 2],
-        ("validation", "ORG"): [2, 3],
-        ("validation", "LOC"): [2],
-        ("validation", "MISC"): [2],
-        ("validation", "PER"): [2],
-    }
-    prepared_data = prepare_data(
-        dataset=dataset, metric=partial(document_field_length_collector, field="text")
-    )
-    assert prepared_data == {
-        ("train",): [48, 15, 19],
-        ("test",): [57, 11, 40],
-        ("validation",): [65, 17, 187],
     }


### PR DESCRIPTION
This add `DocumentStatistics`, an abstract class derived from `DocumentMetrics` to easily collect statistics over datasets. It requires to implement a method `_collect(doc: Document) -> Any`. It should calculate any values over the document, can return naive types (such as int, float, str), dicts, or lists. 
  
The `_compute()` will aggregate the results of `_collect()` in the following way : naive types are arranged in a list, lists are concatenated, and dictionaries are flattened and their values are handled such as naive types or lists, respectively, and finally unflattened again (this is because calling the `DocumentMetric` on a `DatasetDict` will produce a dictionary with the split names as keys and the metric results as values, so this would result in a semi-flattened dict, if we would not unflatten again).

This also implements the following document statistics:
 - `TokenCountCollector` (formerly `DocumentTokenCounter`): Collects the token count of a field when tokenizing its content with a Huggingface tokenizer.
 - `FieldLengthCollector` (formerly `DocumentFieldLengthCounter`): Collects the length of a field, e.g. to collect the number the characters in the input text.
 - `SubFieldLengthCollector` (formerly `DocumentSubFieldLengthCounter`): Collects the length of a subfield in a field, e.g. to collect the number of arguments of N-ary relations.
 - `LabeledSpanLengthCollector` (formerly `DocumentSpanLengthCounter`): Counts the length of spans in a field per label, e.g. to collect the length of entities per type.
 - `DummyCollector` (formerly `DummyCounter`): A dummy collector that always returns 1, e.g. to count the number of documents.
 - `LabelCountCollector` (formerly `LabelCounter`): Collects the number of field entries per label, e.g. to collect the number of entities per type.