### PR TITLE
aggregate the result of DocumentStatistic

### DIFF
--- a/src/pytorch_ie/core/metric.py
+++ b/src/pytorch_ie/core/metric.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, Iterable, TypeVar, Union
+from typing import Dict, Generic, Iterable, Optional, TypeVar, Union
 
 from pytorch_ie.core.document import Document
 
@@ -11,6 +11,7 @@ class DocumentMetric(ABC, Generic[T]):
 
     def __init__(self):
         self.reset()
+        self._current_split: Optional[str] = None
 
     @abstractmethod
     def reset(self) -> None:
@@ -33,9 +34,11 @@ class DocumentMetric(ABC, Generic[T]):
         elif isinstance(document_or_collection, dict):
             result: Dict[str, T] = {}
             for split_name, split in document_or_collection.items():
+                self._current_split = split_name
                 self.reset()
                 split_values: T = self(split)  # type: ignore
                 result[split_name] = split_values
+                self._current_split = None
             return result
         elif isinstance(document_or_collection, Iterable):
             for doc in document_or_collection:
@@ -64,3 +67,8 @@ class DocumentMetric(ABC, Generic[T]):
     @abstractmethod
     def _compute(self) -> T:
         """This method is called to get the metric values."""
+
+    @property
+    def current_split(self) -> Optional[str]:
+        """The current split that is being processed."""
+        return self._current_split

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -168,9 +168,11 @@ class DocumentStatistic(DocumentMetric):
                 else:
                     stats[()].append(collected_result)
         if self.current_split is not None:
-            title = f"{self.title} (split: {self.current_split}, {len(self._values)} documents)"
+            title = (
+                f"{self.title} (split: {self.current_split}, {len(self._values)} collected values)"
+            )
         else:
-            title = f"{self.title} ({len(self._values)} documents)"
+            title = f"{self.title} ({len(self._values)} collected values)"
         if self.show_histogram:
             import plotext as plt
 

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -168,11 +168,9 @@ class DocumentStatistic(DocumentMetric):
                 else:
                     stats[()].append(collected_result)
         if self.current_split is not None:
-            title = (
-                f"{self.title} (split: {self.current_split}, {len(self._values)} collected values)"
-            )
+            title = f"{self.title} (split: {self.current_split}, {len(self._values)} documents)"
         else:
-            title = f"{self.title} ({len(self._values)} collected values)"
+            title = f"{self.title} ({len(self._values)} documents)"
         if self.show_histogram:
             import plotext as plt
 

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -167,7 +167,10 @@ class DocumentStatistic(DocumentMetric):
                     stats[()].extend(collected_result)
                 else:
                     stats[()].append(collected_result)
-        title = f"{self.title} ({len(self._values)} documents)"
+        if self.current_split is not None:
+            title = f"{self.title} (split: {self.current_split}, {len(self._values)} documents)"
+        else:
+            title = f"{self.title} ({len(self._values)} documents)"
         if self.show_histogram:
             import plotext as plt
 

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -176,7 +176,7 @@ class DocumentStatistic(DocumentMetric):
 
             for k, values in stats.items():
                 if isinstance(values, list):
-                    plt.hist(values, label=k.join(".") if len(k) > 0 else None)
+                    plt.hist(values, label=".".join(k) if len(k) > 0 else None)
             plt.title(title)
             plt.show()
             plt.clear_figure()

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -128,6 +128,7 @@ class DocumentStatistic(DocumentMetric):
         show_histogram: bool = False,
         show_as_markdown: bool = False,
         aggregation_functions: Optional[List[str]] = None,
+        title: Optional[str] = None,
     ) -> None:
         super().__init__()
         self.aggregation_functions = {
@@ -136,6 +137,7 @@ class DocumentStatistic(DocumentMetric):
         }
         self.show_histogram = show_histogram
         self.show_as_markdown = show_as_markdown
+        self.title = title or self.__class__.__name__
 
     def reset(self) -> None:
         self._values: List[Any] = []
@@ -165,7 +167,7 @@ class DocumentStatistic(DocumentMetric):
                     stats[()].extend(collected_result)
                 else:
                     stats[()].append(collected_result)
-        title = f"{self.__class__.__name__} ({len(self._values)} documents)"
+        title = f"{self.title} ({len(self._values)} documents)"
         if self.show_histogram:
             import plotext as plt
 

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -176,7 +176,7 @@ class DocumentStatistic(DocumentMetric):
 
             for k, values in stats.items():
                 if isinstance(values, list):
-                    plt.hist(values, label=k)
+                    plt.hist(values, label=k.join(".") if len(k) > 0 else None)
             plt.title(title)
             plt.show()
             plt.clear_figure()

--- a/tests/core/test_statistic.py
+++ b/tests/core/test_statistic.py
@@ -5,7 +5,6 @@ import pytest
 from pytorch_ie import DatasetDict
 from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.core.statistic import flatten_dict
 from pytorch_ie.documents import TextBasedDocument
 from pytorch_ie.metrics.statistics import (
     DummyCollector,
@@ -30,75 +29,137 @@ def dataset():
     )
 
 
-def test_prepare_data(dataset):
+def test_statistics(dataset):
     statistic = DummyCollector()
-    values_nested = statistic(dataset)
-    prepared_data = flatten_dict(values_nested)
-    assert prepared_data == {
-        ("train",): [1, 1, 1],
-        ("test",): [1, 1, 1],
-        ("validation",): [1, 1, 1],
+    values = statistic(dataset)
+    assert values == {"train": {"sum": 3}, "test": {"sum": 3}, "validation": {"sum": 3}}
+
+    statistic = LabelCountCollector(field="entities", labels=["LOC", "PER", "ORG", "MISC"])
+    values = statistic(dataset)
+    assert values == {
+        "test": {
+            "LOC": {"len": 3, "max": 2, "mean": 1.0, "min": 0, "std": 0.816496580927726},
+            "MISC": {"len": 3, "max": 0, "mean": 0.0, "min": 0, "std": 0.0},
+            "ORG": {"len": 3, "max": 0, "mean": 0.0, "min": 0, "std": 0.0},
+            "PER": {
+                "len": 3,
+                "max": 1,
+                "mean": 0.6666666666666666,
+                "min": 0,
+                "std": 0.4714045207910317,
+            },
+        },
+        "train": {
+            "LOC": {
+                "len": 3,
+                "max": 1,
+                "mean": 0.3333333333333333,
+                "min": 0,
+                "std": 0.4714045207910317,
+            },
+            "MISC": {
+                "len": 3,
+                "max": 2,
+                "mean": 0.6666666666666666,
+                "min": 0,
+                "std": 0.9428090415820634,
+            },
+            "ORG": {
+                "len": 3,
+                "max": 1,
+                "mean": 0.3333333333333333,
+                "min": 0,
+                "std": 0.4714045207910317,
+            },
+            "PER": {
+                "len": 3,
+                "max": 1,
+                "mean": 0.3333333333333333,
+                "min": 0,
+                "std": 0.4714045207910317,
+            },
+        },
+        "validation": {
+            "LOC": {
+                "len": 3,
+                "max": 1,
+                "mean": 0.3333333333333333,
+                "min": 0,
+                "std": 0.4714045207910317,
+            },
+            "MISC": {
+                "len": 3,
+                "max": 1,
+                "mean": 0.3333333333333333,
+                "min": 0,
+                "std": 0.4714045207910317,
+            },
+            "ORG": {"len": 3, "max": 2, "mean": 1.0, "min": 0, "std": 0.816496580927726},
+            "PER": {
+                "len": 3,
+                "max": 1,
+                "mean": 0.3333333333333333,
+                "min": 0,
+                "std": 0.4714045207910317,
+            },
+        },
     }
-    statistic = LabelCountCollector(field="entities")
-    values_nested = statistic(dataset)
-    prepared_data = flatten_dict(values_nested)
-    assert prepared_data == {
-        ("train", "ORG"): [2],
-        ("train", "MISC"): [3],
-        ("train", "PER"): [2],
-        ("train", "LOC"): [2],
-        ("test", "LOC"): [2, 3],
-        ("test", "PER"): [2, 2],
-        ("validation", "ORG"): [2, 3],
-        ("validation", "LOC"): [2],
-        ("validation", "MISC"): [2],
-        ("validation", "PER"): [2],
-    }
+
     statistic = FieldLengthCollector(field="text")
-    values_nested = statistic(dataset)
-    prepared_data = flatten_dict(values_nested)
-    assert prepared_data == {
-        ("train",): [48, 15, 19],
-        ("test",): [57, 11, 40],
-        ("validation",): [65, 17, 187],
+    values = statistic(dataset)
+    assert values == {
+        "test": {"max": 57, "mean": 36.0, "min": 11, "std": 18.991226044325487},
+        "train": {"max": 48, "mean": 27.333333333333332, "min": 15, "std": 14.70449666674185},
+        "validation": {"max": 187, "mean": 89.66666666666667, "min": 17, "std": 71.5603863103665},
     }
 
     statistic = LabeledSpanLengthCollector(field="entities")
-    values_nested = statistic(dataset)
-    prepared_data = flatten_dict(values_nested)
-    assert prepared_data == {
-        ("train", "ORG"): [2],
-        ("train", "MISC"): [6, 7],
-        ("train", "PER"): [15],
-        ("train", "LOC"): [8],
-        ("test", "LOC"): [5, 6, 20],
-        ("test", "PER"): [5, 11],
-        ("validation", "ORG"): [14, 14, 8],
-        ("validation", "LOC"): [6],
-        ("validation", "MISC"): [11],
-        ("validation", "PER"): [12],
+    values = statistic(dataset)
+    assert values == {
+        "train": {
+            "ORG": {"mean": 2.0, "std": 0.0, "min": 2, "max": 2, "len": 1},
+            "MISC": {"mean": 6.5, "std": 0.5, "min": 6, "max": 7, "len": 2},
+            "PER": {"mean": 15.0, "std": 0.0, "min": 15, "max": 15, "len": 1},
+            "LOC": {"mean": 8.0, "std": 0.0, "min": 8, "max": 8, "len": 1},
+        },
+        "test": {
+            "LOC": {
+                "mean": 10.333333333333334,
+                "std": 6.847546194724712,
+                "min": 5,
+                "max": 20,
+                "len": 3,
+            },
+            "PER": {"mean": 8.0, "std": 3.0, "min": 5, "max": 11, "len": 2},
+        },
+        "validation": {
+            "ORG": {"mean": 12.0, "std": 2.8284271247461903, "min": 8, "max": 14, "len": 3},
+            "LOC": {"mean": 6.0, "std": 0.0, "min": 6, "max": 6, "len": 1},
+            "MISC": {"mean": 11.0, "std": 0.0, "min": 11, "max": 11, "len": 1},
+            "PER": {"mean": 12.0, "std": 0.0, "min": 12, "max": 12, "len": 1},
+        },
     }
 
     # this is not super useful, we just collect teh lengths of the labels, but it is enough to test the code
     statistic = SubFieldLengthCollector(field="entities", subfield="label")
-    values_nested = statistic(dataset)
-    prepared_data = flatten_dict(values_nested)
-    assert prepared_data == {
-        ("train",): [3, 4, 4, 3, 3],
-        ("test",): [3, 3, 3, 3, 3],
-        ("validation",): [3, 3, 4, 3, 3, 3],
+    values = statistic(dataset)
+    assert values == {
+        "test": {"max": 3, "mean": 3.0, "min": 3, "std": 0.0},
+        "train": {"max": 4, "mean": 3.4, "min": 3, "std": 0.4898979485566356},
+        "validation": {"max": 4, "mean": 3.1666666666666665, "min": 3, "std": 0.3726779962499649},
     }
 
 
 @pytest.mark.slow
-def test_prepare_data_tokenize(dataset):
+def test_statistics_with_tokenize(dataset):
     statistic = TokenCountCollector(
-        field="text", tokenizer_name_or_path="bert-base-uncased", add_special_tokens=False
+        text_field="text",
+        tokenizer="bert-base-uncased",
+        tokenizer_kwargs=dict(add_special_tokens=False),
     )
-    values_nested = statistic(dataset)
-    prepared_data = flatten_dict(values_nested)
-    assert prepared_data == {
-        ("train",): [9, 2, 6],
-        ("test",): [12, 4, 12],
-        ("validation",): [11, 6, 38],
+    values = statistic(dataset)
+    assert values == {
+        "test": {"max": 12, "mean": 9.333333333333334, "min": 4, "std": 3.7712361663282534},
+        "train": {"max": 9, "mean": 5.666666666666667, "min": 2, "std": 2.8674417556808756},
+        "validation": {"max": 38, "mean": 18.333333333333332, "min": 6, "std": 14.055445761538678},
     }


### PR DESCRIPTION
This PR modifies the `DocumentStatistic` 
 - to return aggregated results instead of the lists of collected values. The default aggregation functions can be set via the class variable `DEFAULT_AGGREGATION_FUNCTIONS: List[str]` (the fucntion names are resolved against some inhouse methods (`mean`, `median`, `std`), or python builtin functions and, if this does not work, against the global namespace via `utils.hydra.resolve_target`).
 - adds the parameter `show_histogram`: Iff `True` (default: `False`), show the histogram of the collected values with `plotext` on the console
 - adds the parameter `show_as_markdown`: Iff `True` (default: `False`), show the result as markdown on the console (requires the `tabulate` package)
 - adds the parameter `title`: this is used in the histogram and markdown table captions

This also adds the property `current_split` to the `DocumentMetric` which is available when processing a dataset dict.

Note: This is breaking with respect to #312 because before this PR, the `DocumentStatistic`  returned a dict with list values, but now the values are aggregated (we do not label it as breaking because #312 was not yet part of a release). However, by using `aggregation_functions=["list"]` the previous behavior can be more or less restored (just the keys are a bit different).