### PR TITLE
conversion of text based document to token based and tokenize document

### DIFF
--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -1,4 +1,5 @@
 import dataclasses
+import logging
 import typing
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
@@ -16,6 +17,8 @@ from typing import (
     Union,
     overload,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _enumerate_dependencies(
@@ -675,6 +678,7 @@ class Document(Mapping[str, Any]):
         override_annotations: Optional[Dict[str, Dict[int, Annotation]]] = None,
         process_predictions: bool = True,
         strict: bool = True,
+        verbose: bool = True,
     ) -> None:
         """Adds all annotations from another document to this document.
 
@@ -702,6 +706,8 @@ class Document(Mapping[str, Any]):
             strict: Whether to raise an exception if the other document contains annotations that reference
                 annotations that are not present in the current document (see parameter removed_annotations).
                 If set to False, the annotations are ignored.
+            verbose: Whether to print a warning if the other document contains annotations that reference
+                annotations that are not present in the current document (see parameter removed_annotations).
 
         Example:
                 ```
@@ -794,6 +800,12 @@ class Document(Mapping[str, Any]):
                                 f"Could not add annotation {ann} to {type(self).__name__} because it depends on "
                                 f"annotations that are not present in the document."
                             )
+                        if verbose:
+                            logger.warning(
+                                f"Could not add annotation {ann} to {type(self).__name__} because it depends on "
+                                f"annotations that are not present in the document. The annotation is ignored."
+                                f"(disable this warning with verbose=False)"
+                            )
                         # The annotation was removed, so we need to make sure that it is not referenced by any other
                         removed_annotations[field_name].add(ann._id)
                 if process_predictions:
@@ -811,6 +823,12 @@ class Document(Mapping[str, Any]):
                                 raise ValueError(
                                     f"Could not add annotation {ann} to {type(self).__name__} because it depends on "
                                     f"annotations that are not present in the document."
+                                )
+                            if verbose:
+                                logger.warning(
+                                    f"Could not add annotation {ann} to {type(self).__name__} because it depends on "
+                                    f"annotations that are not present in the document. The annotation is ignored. "
+                                    f"(disable this warning with verbose=False)"
                                 )
                             # The annotation was removed, so we need to make sure that it is not referenced by any other
                             removed_annotations[field_name].add(ann._id)

--- a/src/pytorch_ie/core/document.py
+++ b/src/pytorch_ie/core/document.py
@@ -303,7 +303,9 @@ class Annotation:
         kwargs.update(overrides)
         return type(self)(**kwargs)
 
-    def copy_with_store(self, override_annotation_store: Dict[int, "Annotation"]) -> "Annotation":
+    def copy_with_store(
+        self, override_annotation_store: Dict[int, "Annotation"], invalid_annotation_ids: Set[int]
+    ) -> Optional["Annotation"]:
         """
         Create a detached copy of the annotation, but replace references to other annotations
         with entries from an override annotation store.
@@ -313,7 +315,10 @@ class Annotation:
         Args:
             :param override_annotation_store: the annotation store to use, a mapping from original *annotation ids*
                 to the new *annotations*
-            :return: a detached copy of the annotation
+            :param invalid_annotation_ids: a set of annotation ids that are not valid anymore and so any Annotation that
+                references one of these ids will be discarded
+            :return: a detached copy of the annotation or None if the annotation contains references to invalid
+                annotations
         """
         overrides: Dict[str, Any] = {}
         for f in dataclasses.fields(self):
@@ -321,8 +326,16 @@ class Annotation:
                 continue
             field_value = getattr(self, f.name)
             if isinstance(field_value, Annotation):
+                if field_value._id in invalid_annotation_ids:
+                    return None
                 overrides[f.name] = override_annotation_store.get(field_value._id, field_value)
             elif isinstance(field_value, tuple):
+                if any(
+                    maybe_anno._id in invalid_annotation_ids
+                    for maybe_anno in field_value
+                    if isinstance(maybe_anno, Annotation)
+                ):
+                    return None
                 overrides[f.name] = tuple(
                     override_annotation_store.get(maybe_anno._id, maybe_anno)
                     if isinstance(maybe_anno, Annotation)
@@ -658,8 +671,10 @@ class Document(Mapping[str, Any]):
     def add_all_annotations_from_other(
         self,
         other: "Document",
-        override_annotation_mapping: Optional[Dict[str, Dict[int, Annotation]]] = None,
+        removed_annotations: Optional[Dict[str, Set[int]]] = None,
+        override_annotations: Optional[Dict[str, Dict[int, Annotation]]] = None,
         process_predictions: bool = True,
+        strict: bool = True,
     ) -> None:
         """Adds all annotations from another document to this document.
 
@@ -667,7 +682,7 @@ class Document(Mapping[str, Any]):
             other: The document to add annotations from.
             process_predictions: Whether to process predictions as well (default: True). If set to False,
                 the predictions in the other document will be ignored.
-            override_annotation_mapping: A mapping from annotation field names to a mapping from
+            override_annotations: A mapping from annotation field names to a mapping from
                 annotation IDs to annotations. The effects are two-fold. First, adding any annotation
                 field name as key has the effect that the field is expected to be already handled and
                 no annotations will be added from the other document. Second, if a certain mapping
@@ -675,8 +690,20 @@ class Document(Mapping[str, Any]):
                 the new_annotation will be used anywhere where the old_annotation would have been
                 referenced. This propagates along the annotation graph and can be useful if some
                 annotations are modified, but all dependent annotations should be kept intact e.g.
-                when converting a text-based document to token-based (or the other way around):
+                when converting a text-based document to token-based (or the other way around). See below
+                for an example.
+            removed_annotations: A mapping from annotation field names to a set of annotation ids that
+                are removed from the document. This is useful if e.g. the annotation base (the text)
+                is split up and the annotations need to be split up as well or if conversion to a token base
+                is performed, but some spans could not be converted, because of aligning issues, and, thus,
+                should be removed. Similar as for entries in override_annotations, fields that are mentioned
+                in removed_annotations are expected to be already handled manually and will not be added from
+                the other document. Also, the removal of annotations propagates along the annotation graph.
+            strict: Whether to raise an exception if the other document contains annotations that reference
+                annotations that are not present in the current document (see parameter removed_annotations).
+                If set to False, the annotations are ignored.
 
+        Example:
                 ```
                 @dataclasses.dataclass(frozen=True)
                 class Attribute(Annotation):
@@ -712,17 +739,18 @@ class Document(Mapping[str, Any]):
                 doc_tokens.entities.extend([e1_tokens, e2_tokens])
                 doc_tokens.add_all_annotations_from_other(
                     other=doc_text,
-                    override_annotation_mapping={"entities": {e1_text._id: e1_tokens, e2_text._id: e2_tokens}},
+                    override_annotations={"entities": {e1_text._id: e1_tokens, e2_text._id: e2_tokens}},
                 )
                 # Note that the relation and attribute are still present, but now refer to the new entities
                 # and new relation, respectively.
                 ```
         """
+        removed_annotations = defaultdict(set, removed_annotations or dict())
 
         annotation_store: Dict[str, Dict[int, Annotation]] = defaultdict(dict)
         named_annotation_fields = {field.name: field for field in self.annotation_fields()}
-        if override_annotation_mapping is not None:
-            for field_name, mapping in override_annotation_mapping.items():
+        if override_annotations is not None:
+            for field_name, mapping in override_annotations.items():
                 if field_name not in named_annotation_fields:
                     raise ValueError(
                         f'Field "{field_name}" is not an annotation field of {type(self).__name__}, but keys in '
@@ -730,7 +758,7 @@ class Document(Mapping[str, Any]):
                     )
                 annotation_store[field_name].update(mapping)
         else:
-            override_annotation_mapping = dict()
+            override_annotations = dict()
 
         dependency_ordered_fields: List[str] = []
         _enumerate_dependencies(
@@ -739,26 +767,53 @@ class Document(Mapping[str, Any]):
             nodes=self._annotation_graph["_artificial_root"],
         )
         for field_name in dependency_ordered_fields:
-            if (
-                field_name in named_annotation_fields
-                and field_name not in override_annotation_mapping
+            # we process only annotation fields that are not in the override_annotations and the removed_annotations
+            # mapping because they are meant to be already manually handled
+            if field_name in named_annotation_fields and field_name not in (
+                set(override_annotations) | set(removed_annotations)
             ):
                 current_targets_store = dict()
+                current_invalid_annotation_ids = set()
                 for target in self._annotation_graph.get(field_name, []):
                     current_targets_store.update(annotation_store[target])
+                    current_invalid_annotation_ids.update(removed_annotations.get(target, set()))
 
                 other_annotation_field = other[field_name]
                 for ann in other_annotation_field:
-                    new_ann = ann.copy_with_store(current_targets_store)
-                    if ann._id != new_ann._id:
-                        annotation_store[field_name][ann._id] = new_ann
-                    self[field_name].append(new_ann)
-                if process_predictions:
-                    for ann in other_annotation_field.predictions:
-                        new_ann = ann.copy_with_store(current_targets_store)
+                    new_ann = ann.copy_with_store(
+                        override_annotation_store=current_targets_store,
+                        invalid_annotation_ids=current_invalid_annotation_ids,
+                    )
+                    if new_ann is not None:
                         if ann._id != new_ann._id:
                             annotation_store[field_name][ann._id] = new_ann
-                        self[field_name].predictions.append(new_ann)
+                        self[field_name].append(new_ann)
+                    else:
+                        if strict:
+                            raise ValueError(
+                                f"Could not add annotation {ann} to {type(self).__name__} because it depends on "
+                                f"annotations that are not present in the document."
+                            )
+                        # The annotation was removed, so we need to make sure that it is not referenced by any other
+                        removed_annotations[field_name].add(ann._id)
+                if process_predictions:
+                    for ann in other_annotation_field.predictions:
+                        new_ann = ann.copy_with_store(
+                            override_annotation_store=current_targets_store,
+                            invalid_annotation_ids=current_invalid_annotation_ids,
+                        )
+                        if new_ann is not None:
+                            if ann._id != new_ann._id:
+                                annotation_store[field_name][ann._id] = new_ann
+                            self[field_name].predictions.append(new_ann)
+                        else:
+                            if strict:
+                                raise ValueError(
+                                    f"Could not add annotation {ann} to {type(self).__name__} because it depends on "
+                                    f"annotations that are not present in the document."
+                                )
+                            # The annotation was removed, so we need to make sure that it is not referenced by any other
+                            removed_annotations[field_name].add(ann._id)
 
 
 def resolve_annotation(

--- a/src/pytorch_ie/data/__init__.py
+++ b/src/pytorch_ie/data/__init__.py
@@ -2,7 +2,7 @@ from .builder import GeneratorBasedBuilder
 from .dataset import Dataset, IterableDataset
 from .dataset_dict import DatasetDict
 from .dataset_formatter import DocumentFormatter
-from .document_conversion import text_based_document_to_token_based
+from .document_conversion import text_based_document_to_token_based, tokenize_document
 
 __all__ = [
     "GeneratorBasedBuilder",
@@ -11,4 +11,5 @@ __all__ = [
     "DatasetDict",
     "DocumentFormatter",
     "text_based_document_to_token_based",
+    "tokenize_document",
 ]

--- a/src/pytorch_ie/data/__init__.py
+++ b/src/pytorch_ie/data/__init__.py
@@ -2,6 +2,7 @@ from .builder import GeneratorBasedBuilder
 from .dataset import Dataset, IterableDataset
 from .dataset_dict import DatasetDict
 from .dataset_formatter import DocumentFormatter
+from .document_conversion import text_based_document_to_token_based
 
 __all__ = [
     "GeneratorBasedBuilder",
@@ -9,4 +10,5 @@ __all__ = [
     "IterableDataset",
     "DatasetDict",
     "DocumentFormatter",
+    "text_based_document_to_token_based",
 ]

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -19,7 +19,7 @@ def text_based_document_to_token_based(
     result_document_type: Type[T],
     token_offset_mapping: Optional[List[Tuple[int, int]]] = None,
     char_to_token: Optional[Callable[[int], Optional[int]]] = None,
-    strict: bool = True,
+    strict_span_conversion: bool = True,
 ) -> T:
     result = result_document_type(tokens=tuple(tokens), id=doc.id, metadata=deepcopy(doc.metadata))
 
@@ -59,7 +59,7 @@ def text_based_document_to_token_based(
             start_token_idx = char_to_token(char_span.start)
             end_token_idx_inclusive = char_to_token(char_span.end - 1)
             if start_token_idx is None or end_token_idx_inclusive is None:
-                if strict:
+                if strict_span_conversion:
                     raise ValueError(
                         f'cannot find token span for character span: "{char_span}", text="{doc.text}", '
                         f"token_offset_mapping={token_offset_mapping}"
@@ -90,7 +90,7 @@ def tokenize_document(
     doc: TextBasedDocument,
     tokenizer: PreTrainedTokenizer,
     result_document_type: Type[T],
-    strict: bool = True,
+    strict_span_conversion: bool = True,
     **tokenize_kwargs,
 ) -> T:
     tokenized_text = tokenizer(doc.text, return_offsets_mapping=True, **tokenize_kwargs)
@@ -103,6 +103,6 @@ def tokenize_document(
         result_document_type=result_document_type,
         token_offset_mapping=token_offset_mapping,
         char_to_token=char_to_token,
-        strict=strict,
+        strict_span_conversion=strict_span_conversion,
     )
     return tokenized_document

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -2,6 +2,8 @@ import logging
 from copy import deepcopy
 from typing import Callable, Dict, List, Optional, Tuple, Type, TypeVar
 
+from transformers import PreTrainedTokenizer
+
 from pytorch_ie.annotations import Span
 from pytorch_ie.core import Annotation
 from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
@@ -82,3 +84,24 @@ def text_based_document_to_token_based(
     )
 
     return result
+
+
+def tokenize_document(
+    doc: TextBasedDocument,
+    tokenizer: PreTrainedTokenizer,
+    result_document_type: Type[T],
+    strict: bool = True,
+) -> T:
+    tokenized_text = tokenizer(doc.text, return_offsets_mapping=True)
+    tokens = tokenized_text.tokens()
+    token_offset_mapping = tokenized_text.offset_mapping
+    char_to_token = tokenized_text.char_to_token
+    tokenized_document = text_based_document_to_token_based(
+        doc,
+        tokens=tokens,
+        result_document_type=result_document_type,
+        token_offset_mapping=token_offset_mapping,
+        char_to_token=char_to_token,
+        strict=strict,
+    )
+    return tokenized_document

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -1,0 +1,73 @@
+import logging
+from copy import deepcopy
+from typing import Callable, Dict, List, Optional, Tuple, Type, TypeVar
+
+from pytorch_ie.annotations import Span
+from pytorch_ie.core import Annotation
+from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=TokenBasedDocument)
+
+
+def text_based_document_to_token_based(
+    doc: TextBasedDocument,
+    tokens: List[str],
+    text_span_layers: List[str],
+    result_document_type: Type[T],
+    token_offset_mapping: Optional[List[Tuple[int, int]]] = None,
+    char_to_token: Optional[Callable[[int], Optional[int]]] = None,
+    strict: bool = True,
+) -> T:
+    if char_to_token is None:
+        if token_offset_mapping is None:
+            raise ValueError(
+                "either token_offset_mapping or char_to_token must be provided to convert a text "
+                "based document to token based, but both are None"
+            )
+        char_to_token_dict: Dict[int, int] = {}
+        for token_idx, (start, end) in enumerate(token_offset_mapping):
+            for char_idx in range(start, end):
+                char_to_token_dict[char_idx] = token_idx
+
+        def char_to_token(char_idx: int) -> Optional[int]:
+            return char_to_token_dict.get(char_idx)
+
+    result = result_document_type(tokens=tokens, id=doc.id, metadata=deepcopy(doc.metadata))
+
+    override_annotation_mapping: Dict[str, Dict[int, Annotation]] = {}
+    for text_span_layer_name in text_span_layers:
+        override_annotation_mapping[text_span_layer_name] = {}
+        char_span: Span
+        for char_span in doc[text_span_layer_name]:
+            start_token_idx = char_to_token(char_span.start)
+            end_token_idx_inclusive = char_to_token(char_span.end - 1)
+            if start_token_idx is None or end_token_idx_inclusive is None:
+                if strict:
+                    raise ValueError(
+                        f"cannot find token span for char span: {char_span}, "
+                        f"token_offset_mapping={token_offset_mapping}"
+                    )
+                else:
+                    logger.warning(f"cannot find token for char span {char_span}, skip it")
+                    continue
+            token_span = char_span.copy(start=start_token_idx, end=end_token_idx_inclusive + 1)
+            override_annotation_mapping[text_span_layer_name][char_span._id] = token_span
+
+        result[text_span_layer_name].extend(
+            set(override_annotation_mapping[text_span_layer_name].values())
+        )
+
+    result.add_all_annotations_from_other(
+        doc, override_annotation_mapping=override_annotation_mapping
+    )
+
+    # save text, token_offset_mapping and char_to_token (if available) in metadata
+    result.metadata["text"] = doc.text
+    if token_offset_mapping is not None:
+        result.metadata["token_offset_mapping"] = token_offset_mapping
+    if char_to_token is not None:
+        result.metadata["char_to_token"] = char_to_token
+
+    return result

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -14,7 +14,6 @@ T = TypeVar("T", bound=TokenBasedDocument)
 def text_based_document_to_token_based(
     doc: TextBasedDocument,
     tokens: List[str],
-    text_span_layers: List[str],
     result_document_type: Type[T],
     token_offset_mapping: Optional[List[Tuple[int, int]]] = None,
     char_to_token: Optional[Callable[[int], Optional[int]]] = None,
@@ -43,6 +42,12 @@ def text_based_document_to_token_based(
 
         def char_to_token(char_idx: int) -> Optional[int]:
             return char_to_token_dict.get(char_idx)
+
+    text_span_layers = [
+        annotation_field.name
+        for annotation_field in doc.annotation_fields()
+        if "text" in annotation_field.metadata["targets"]
+    ]
 
     override_annotation_mapping: Dict[str, Dict[int, Annotation]] = {}
     for text_span_layer_name in text_span_layers:

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -34,7 +34,7 @@ def text_based_document_to_token_based(
         def char_to_token(char_idx: int) -> Optional[int]:
             return char_to_token_dict.get(char_idx)
 
-    result = result_document_type(tokens=tokens, id=doc.id, metadata=deepcopy(doc.metadata))
+    result = result_document_type(tokens=tuple(tokens), id=doc.id, metadata=deepcopy(doc.metadata))
 
     override_annotation_mapping: Dict[str, Dict[int, Annotation]] = {}
     for text_span_layer_name in text_span_layers:

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -96,18 +96,20 @@ def tokenize_document(
     tokenizer: PreTrainedTokenizer,
     result_document_type: Type[T],
     strict_span_conversion: bool = True,
+    verbose: bool = True,
     **tokenize_kwargs,
-) -> T:
+) -> List[T]:
     tokenized_text = tokenizer(doc.text, return_offsets_mapping=True, **tokenize_kwargs)
-    tokens = tokenized_text.tokens()
-    token_offset_mapping = tokenized_text.offset_mapping
-    char_to_token = tokenized_text.char_to_token
-    tokenized_document = text_based_document_to_token_based(
-        doc,
-        tokens=tokens,
-        result_document_type=result_document_type,
-        token_offset_mapping=token_offset_mapping,
-        char_to_token=char_to_token,
-        strict_span_conversion=strict_span_conversion,
-    )
-    return tokenized_document
+    result = []
+    for batch_encoding in tokenized_text.encodings:
+        tokenized_document = text_based_document_to_token_based(
+            doc,
+            tokens=batch_encoding.tokens,
+            result_document_type=result_document_type,
+            token_offset_mapping=batch_encoding.offsets,
+            char_to_token=batch_encoding.char_to_token,
+            strict_span_conversion=strict_span_conversion,
+            verbose=verbose,
+        )
+        result.append(tokenized_document)
+    return result

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -56,7 +56,10 @@ def text_based_document_to_token_based(
             override_annotation_mapping[text_span_layer_name][char_span._id] = token_span
 
         result[text_span_layer_name].extend(
-            set(override_annotation_mapping[text_span_layer_name].values())
+            sorted(
+                set(override_annotation_mapping[text_span_layer_name].values()),
+                key=lambda span: span.start,
+            )
         )
 
     result.add_all_annotations_from_other(

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -21,6 +21,7 @@ def text_based_document_to_token_based(
     token_offset_mapping: Optional[List[Tuple[int, int]]] = None,
     char_to_token: Optional[Callable[[int], Optional[int]]] = None,
     strict_span_conversion: bool = True,
+    verbose: bool = True,
 ) -> T:
     result = result_document_type(tokens=tuple(tokens), id=doc.id, metadata=deepcopy(doc.metadata))
 
@@ -67,9 +68,11 @@ def text_based_document_to_token_based(
                         f"token_offset_mapping={token_offset_mapping}"
                     )
                 else:
-                    logger.warning(
-                        f'cannot find token span for character span "{char_span}", skip it'
-                    )
+                    if verbose:
+                        logger.warning(
+                            f'cannot find token span for character span "{char_span}", skip it (disable this '
+                            f"warning with verbose=False)"
+                        )
                     removed_annotations[text_span_layer_name].add(char_span._id)
             else:
                 token_span = char_span.copy(start=start_token_idx, end=end_token_idx_inclusive + 1)
@@ -82,6 +85,7 @@ def text_based_document_to_token_based(
         override_annotations=override_annotations,
         removed_annotations=removed_annotations,
         strict=strict_span_conversion,
+        verbose=verbose,
     )
 
     return result

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -91,8 +91,9 @@ def tokenize_document(
     tokenizer: PreTrainedTokenizer,
     result_document_type: Type[T],
     strict: bool = True,
+    **tokenize_kwargs,
 ) -> T:
-    tokenized_text = tokenizer(doc.text, return_offsets_mapping=True)
+    tokenized_text = tokenizer(doc.text, return_offsets_mapping=True, **tokenize_kwargs)
     tokens = tokenized_text.tokens()
     token_offset_mapping = tokenized_text.offset_mapping
     char_to_token = tokenized_text.char_to_token

--- a/tests/data/test_document_conversion.py
+++ b/tests/data/test_document_conversion.py
@@ -36,6 +36,11 @@ def test_text_based_document_to_token_based(documents, tokenizer):
             char_to_token=None if i == 0 else tokenized_text.char_to_token,
         )
         assert tokenized_doc is not None
+
+        # check (de-)serialization
+        tokenized_doc_dict = tokenized_doc.asdict()
+        recreated_tokenized_doc = type(tokenized_doc).fromdict(tokenized_doc_dict)
+
         if i == 0:
             assert doc.id == "train_doc1"
             assert tokenized_doc.metadata["text"] == doc.text == "A single sentence."
@@ -163,8 +168,13 @@ def test_text_based_document_to_token_based_unaligned_span_not_strict(documents,
         token_offset_mapping=tokenized_text.offset_mapping,
         # to increase test coverage
         char_to_token=tokenized_text.char_to_token,
-        strict=False,
+        strict_span_conversion=False,
     )
+
+    # check (de-)serialization
+    tokenized_doc_dict = tokenized_doc.asdict()
+    recreated_tokenized_doc = type(tokenized_doc).fromdict(tokenized_doc_dict)
+
     assert len(doc.entities) == 1
     # the unaligned span is not included in the tokenized document
     assert len(tokenized_doc.entities) == 0
@@ -177,6 +187,10 @@ def test_tokenize_document(documents, tokenizer):
         tokenizer=tokenizer,
         result_document_type=TokenizedTestDocument,
     )
+
+    # check (de-)serialization
+    tokenized_doc_dict = tokenized_doc.asdict()
+    recreated_tokenized_doc = type(tokenized_doc).fromdict(tokenized_doc_dict)
 
     assert doc.id == "train_doc2"
     assert tokenized_doc.metadata["text"] == doc.text == "Entity A works at B."

--- a/tests/data/test_document_conversion.py
+++ b/tests/data/test_document_conversion.py
@@ -1,0 +1,101 @@
+import dataclasses
+
+from transformers import AutoTokenizer, PreTrainedTokenizer
+
+from pytorch_ie import text_based_document_to_token_based
+from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
+from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.documents import TokenBasedDocument
+
+
+def test_text_based_document_to_token_based(documents):
+    @dataclasses.dataclass
+    class TokenizedTestDocument(TokenBasedDocument):
+        sentences: AnnotationList[Span] = annotation_field(target="tokens")
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+    tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+
+    assert len(documents) >= 3
+    for i, doc in enumerate(documents[:3]):
+        tokenized_text = tokenizer(doc.text, return_offsets_mapping=True)
+        tokenized_doc = text_based_document_to_token_based(
+            doc,
+            tokens=tokenized_text.tokens(),
+            text_span_layers=["sentences", "entities"],
+            result_document_type=TokenizedTestDocument,
+            token_offset_mapping=tokenized_text.offset_mapping,
+            char_to_token=tokenized_text.char_to_token,
+        )
+        assert tokenized_doc is not None
+        if i == 0:
+            assert doc.id == "train_doc1"
+            assert doc.text == "A single sentence."
+            assert tokenized_doc.metadata["text"] == doc.text
+            assert tokenized_doc.tokens == ("[CLS]", "A", "single", "sentence", ".", "[SEP]")
+            assert len(tokenized_doc.sentences) == len(doc.sentences) == 1
+            assert str(doc.sentences[0]) == "A single sentence."
+            assert str(tokenized_doc.sentences[0]) == "('A', 'single', 'sentence', '.')"
+            assert len(tokenized_doc.entities) == len(doc.entities) == 0
+            assert len(tokenized_doc.relations) == len(doc.relations) == 0
+        elif i == 1:
+            assert doc.id == "train_doc2"
+            assert doc.text == "Entity A works at B."
+            assert tokenized_doc.metadata["text"] == doc.text
+            assert tokenized_doc.tokens == (
+                "[CLS]",
+                "En",
+                "##ti",
+                "##ty",
+                "A",
+                "works",
+                "at",
+                "B",
+                ".",
+                "[SEP]",
+            )
+            assert len(tokenized_doc.sentences) == len(doc.sentences) == 1
+            assert str(doc.sentences[0]) == "Entity A works at B."
+            assert (
+                str(tokenized_doc.sentences[0])
+                == "('En', '##ti', '##ty', 'A', 'works', 'at', 'B', '.')"
+            )
+            assert len(tokenized_doc.entities) == len(doc.entities) == 2
+            assert str(doc.entities[0]) == "Entity A"
+            assert str(tokenized_doc.entities[0]) == "('En', '##ti', '##ty', 'A')"
+            assert str(doc.entities[1]) == "B"
+            assert str(tokenized_doc.entities[1]) == "('B',)"
+            assert len(tokenized_doc.relations) == len(doc.relations) == 1
+            assert doc.relations[0].head == doc.entities[0]
+            assert tokenized_doc.relations[0].head == tokenized_doc.entities[0]
+            assert doc.relations[0].tail == doc.entities[1]
+            assert tokenized_doc.relations[0].tail == tokenized_doc.entities[1]
+        elif i == 2:
+            assert doc.id == "train_doc3"
+            assert doc.text == "Entity C and D."
+            assert tokenized_doc.metadata["text"] == doc.text
+            assert tokenized_doc.tokens == (
+                "[CLS]",
+                "En",
+                "##ti",
+                "##ty",
+                "C",
+                "and",
+                "D",
+                ".",
+                "[SEP]",
+            )
+            assert len(tokenized_doc.sentences) == len(doc.sentences) == 1
+            assert str(doc.sentences[0]) == "Entity C and D."
+            assert (
+                str(tokenized_doc.sentences[0]) == "('En', '##ti', '##ty', 'C', 'and', 'D', '.')"
+            )
+            assert len(tokenized_doc.entities) == len(doc.entities) == 2
+            assert str(doc.entities[0]) == "Entity C"
+            assert str(tokenized_doc.entities[0]) == "('En', '##ti', '##ty', 'C')"
+            assert str(doc.entities[1]) == "D"
+            assert str(tokenized_doc.entities[1]) == "('D',)"
+            assert len(tokenized_doc.relations) == len(doc.relations) == 0
+        else:
+            raise ValueError(f"Unexpected document: {doc.id}")

--- a/tests/data/test_document_conversion.py
+++ b/tests/data/test_document_conversion.py
@@ -3,10 +3,9 @@ import dataclasses
 import pytest
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
-from pytorch_ie import text_based_document_to_token_based
+from pytorch_ie import text_based_document_to_token_based, tokenize_document
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
 from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.data.document_conversion import tokenize_document
 from pytorch_ie.documents import TokenBasedDocument
 
 

--- a/tests/data/test_document_conversion.py
+++ b/tests/data/test_document_conversion.py
@@ -37,8 +37,9 @@ def test_text_based_document_to_token_based(documents, tokenizer):
         assert tokenized_doc is not None
         if i == 0:
             assert doc.id == "train_doc1"
-            assert doc.text == "A single sentence."
-            assert tokenized_doc.metadata["text"] == doc.text
+            assert tokenized_doc.metadata["text"] == doc.text == "A single sentence."
+            assert tokenized_doc.metadata["token_offset_mapping"] == tokenized_text.offset_mapping
+            assert tokenized_doc.metadata.get("char_to_token") is None
             assert tokenized_doc.tokens == ("[CLS]", "A", "single", "sentence", ".", "[SEP]")
             assert len(tokenized_doc.sentences) == len(doc.sentences) == 1
             assert str(doc.sentences[0]) == "A single sentence."
@@ -47,8 +48,9 @@ def test_text_based_document_to_token_based(documents, tokenizer):
             assert len(tokenized_doc.relations) == len(doc.relations) == 0
         elif i == 1:
             assert doc.id == "train_doc2"
-            assert doc.text == "Entity A works at B."
-            assert tokenized_doc.metadata["text"] == doc.text
+            assert tokenized_doc.metadata["text"] == doc.text == "Entity A works at B."
+            assert tokenized_doc.metadata.get("token_offset_mapping") is None
+            assert tokenized_doc.metadata["char_to_token"] == tokenized_text.char_to_token
             assert tokenized_doc.tokens == (
                 "[CLS]",
                 "En",
@@ -79,8 +81,9 @@ def test_text_based_document_to_token_based(documents, tokenizer):
             assert tokenized_doc.relations[0].tail == tokenized_doc.entities[1]
         elif i == 2:
             assert doc.id == "train_doc3"
-            assert doc.text == "Entity C and D."
-            assert tokenized_doc.metadata["text"] == doc.text
+            assert tokenized_doc.metadata["text"] == doc.text == "Entity C and D."
+            assert tokenized_doc.metadata["token_offset_mapping"] == tokenized_text.offset_mapping
+            assert tokenized_doc.metadata["char_to_token"] == tokenized_text.char_to_token
             assert tokenized_doc.tokens == (
                 "[CLS]",
                 "En",

--- a/tests/data/test_document_conversion.py
+++ b/tests/data/test_document_conversion.py
@@ -28,7 +28,6 @@ def test_text_based_document_to_token_based(documents, tokenizer):
         tokenized_doc = text_based_document_to_token_based(
             doc,
             tokens=tokenized_text.tokens(),
-            text_span_layers=["sentences", "entities"],
             result_document_type=TokenizedTestDocument,
             # to increase test coverage
             token_offset_mapping=None if i == 1 else tokenized_text.offset_mapping,
@@ -115,7 +114,6 @@ def test_text_based_document_to_token_based_missing_args(documents, tokenizer):
         tokenized_doc = text_based_document_to_token_based(
             doc,
             tokens=tokenized_text.tokens(),
-            text_span_layers=["sentences", "entities"],
             result_document_type=TokenizedTestDocument,
         )
     assert (
@@ -135,7 +133,6 @@ def test_text_based_document_to_token_based_unaligned_span_strict(documents, tok
         tokenized_doc = text_based_document_to_token_based(
             doc,
             tokens=tokenized_text.tokens(),
-            text_span_layers=["sentences", "entities"],
             result_document_type=TokenizedTestDocument,
             # to increase test coverage
             token_offset_mapping=tokenized_text.offset_mapping,
@@ -157,7 +154,6 @@ def test_text_based_document_to_token_based_unaligned_span_not_strict(documents,
     tokenized_doc = text_based_document_to_token_based(
         doc,
         tokens=tokenized_text.tokens(),
-        text_span_layers=["sentences", "entities"],
         result_document_type=TokenizedTestDocument,
         # to increase test coverage
         token_offset_mapping=tokenized_text.offset_mapping,

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -649,9 +649,7 @@ def test_document_extend_from_other_full_copy(text_document):
 def test_document_extend_from_other_wrong_override_annotation_mapping(text_document):
     new_doc = type(text_document)(text="Hello World!")
     with pytest.raises(ValueError) as excinfo:
-        new_doc.add_all_annotations_from_other(
-            text_document, override_annotation_mapping={"text": {}}
-        )
+        new_doc.add_all_annotations_from_other(text_document, override_annotations={"text": {}})
     assert (
         str(excinfo.value)
         == 'Field "text" is not an annotation field of TextBasedDocumentWithEntitiesRelationsAndRelationAttributes, '
@@ -683,7 +681,7 @@ def test_document_extend_from_other_override(text_document):
     token_document.entities2.append(e2_new)
     # ... and the remaining annotations
     token_document.add_all_annotations_from_other(
-        text_document, override_annotation_mapping=annotation_mapping
+        text_document, override_annotations=annotation_mapping
     )
 
     assert (

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -703,3 +703,18 @@ def test_document_extend_from_other_override(text_document):
     assert (
         token_document.relation_attributes[0].value == text_document.relation_attributes[0].value
     )
+
+
+def test_document_extend_from_other_remove(text_document):
+    doc_new = type(text_document)(text=text_document.text)
+    doc_new.add_all_annotations_from_other(
+        text_document,
+        removed_annotations={"entities1": {text_document.entities1[0]._id}},
+        strict=False,
+    )
+
+    assert len(doc_new.entities1) == 0
+    assert len(doc_new.entities2) == 1
+    assert len(doc_new.relations) == 0
+    assert len(doc_new.labels) == 1
+    assert len(doc_new.relation_attributes) == 0


### PR DESCRIPTION
This PR:
 - implements `text_based_document_to_token_based()`: convert a text based document + list of tokens + (char_to_token mapper or token_offset_mapping) to a token based document with the respective annotations
 - implements `tokenize_document()`: Takes a text based document and a Huggingface tokenizer, produces a list of token based documents with the respective annotations
 - modify `Document.add_all_annotations_from_other()`: 
    - rename the parameter `override_annotation_mapping` to `override_annotations`
    - add parameter `removed_annotations` to allow for annotation removal that is propagated along the annotation graph in the same way as with `override_annotations`
    - add parameter `strict` to control if missing annotations will cause an error or are ignored
    - add parameter `verbose` to suppress warnings when removing annotations

Especially, `tokenize_document()` works with any `TextBasedDocument` and handles all annotations automatically (changes are propagated along the annotation graph). It processes each batch encoding from the tokenizer output (this allows for windowing, also with striding, out of the box, see [documentation of Huggingface Tokenizers](https://huggingface.co/docs/transformers/main_classes/tokenizer)) and also allows for partitioning with a span annotation layer. 