### PR TITLE
tokenize_document: set text_pair if text is already provided

### DIFF
--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from copy import deepcopy
+from copy import copy, deepcopy
 from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, TypeVar
 
 from transformers import PreTrainedTokenizer
@@ -108,7 +108,12 @@ def tokenize_document(
         partitions = doc[partition_layer]
     for partition in partitions:
         text = doc.text[partition.start : partition.end]
-        tokenized_text = tokenizer(text, **tokenize_kwargs)
+        tokenize_kwargs = copy(tokenize_kwargs)
+        if "text" in tokenize_kwargs:
+            tokenize_kwargs["text_pair"] = text
+        else:
+            tokenize_kwargs["text"] = text
+        tokenized_text = tokenizer(**tokenize_kwargs)
         for batch_encoding in tokenized_text.encodings:
             token_offset_mapping = batch_encoding.offsets
             char_to_token = batch_encoding.char_to_token

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -142,5 +142,6 @@ def tokenize_document(
                 strict_span_conversion=strict_span_conversion,
                 verbose=verbose,
             )
+            tokenized_document.metadata["tokenizer_encoding"] = batch_encoding
             result.append(tokenized_document)
     return result

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -108,12 +108,12 @@ def tokenize_document(
         partitions = doc[partition_layer]
     for partition in partitions:
         text = doc.text[partition.start : partition.end]
-        tokenize_kwargs = copy(tokenize_kwargs)
+        current_tokenize_kwargs = copy(tokenize_kwargs)
         if "text" in tokenize_kwargs:
-            tokenize_kwargs["text_pair"] = text
+            current_tokenize_kwargs["text_pair"] = text
         else:
-            tokenize_kwargs["text"] = text
-        tokenized_text = tokenizer(**tokenize_kwargs)
+            current_tokenize_kwargs["text"] = text
+        tokenized_text = tokenizer(**current_tokenize_kwargs)
         for batch_encoding in tokenized_text.encodings:
             token_offset_mapping = batch_encoding.offsets
             char_to_token = batch_encoding.char_to_token

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -119,6 +119,7 @@ def tokenize_document(
         tokenized_text = tokenizer(**current_tokenize_kwargs)
         for batch_encoding in tokenized_text.encodings:
             token_offset_mapping = batch_encoding.offsets
+            char_to_token: Optional[Callable[[int], Optional[int]]]
             char_to_token = functools.partial(
                 batch_encoding.char_to_token, sequence_index=sequence_index
             )


### PR DESCRIPTION
useful e.g. for question answering where we want to encode the question in the first sequence (`text` parameter) and the  main text aka context in the second sequence (`text_pair` parameter) 

Note: This also adds the tokenizer encoding as `tokenizer_encoding` to the metadata of the respective document.