### PR TITLE
upgrade github workflow constraints

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,5 @@
-pip==22.0.3
-nox==2022.1.7
-nox-poetry==0.9.0
-poetry==1.1.13
-virtualenv==20.13.1
+pip==23.2.1
+nox==2023.4.22
+nox-poetry==1.0.3
+poetry==1.6.1
+virtualenv==20.24.4


### PR DESCRIPTION
TODO:
- [x] check if this fixes the `absl-py` issue, see #245 EDIT: It does not.

NOTE: This should be added in a patch release that just contains this PR to test out the release process without breaking further release content.