### PR TITLE
add model and taskmodule Interface classes

### DIFF
--- a/src/pytorch_ie/models/interface.py
+++ b/src/pytorch_ie/models/interface.py
@@ -1,0 +1,6 @@
+class RequiresModelNameOrPath:
+    pass
+
+
+class RequiresNumClasses:
+    pass

--- a/src/pytorch_ie/models/transformer_seq2seq.py
+++ b/src/pytorch_ie/models/transformer_seq2seq.py
@@ -6,6 +6,7 @@ from transformers.modeling_outputs import Seq2SeqLMOutput
 from typing_extensions import TypeAlias
 
 from pytorch_ie.core import PyTorchIEModel
+from pytorch_ie.models.interface import RequiresModelNameOrPath
 
 ModelInputType: TypeAlias = BatchEncoding
 ModelOutputType: TypeAlias = Seq2SeqLMOutput
@@ -14,7 +15,7 @@ ModelStepInputType: TypeAlias = Tuple[ModelInputType]
 
 
 @PyTorchIEModel.register()
-class TransformerSeq2SeqModel(PyTorchIEModel):
+class TransformerSeq2SeqModel(PyTorchIEModel, RequiresModelNameOrPath):
     def __init__(self, model_name_or_path: str, learning_rate: float = 1e-5, **kwargs) -> None:
         super().__init__(**kwargs)
 

--- a/src/pytorch_ie/models/transformer_span_classification.py
+++ b/src/pytorch_ie/models/transformer_span_classification.py
@@ -9,6 +9,7 @@ from transformers import AutoConfig, AutoModel, BatchEncoding, get_linear_schedu
 from typing_extensions import TypeAlias
 
 from pytorch_ie.core import PyTorchIEModel
+from pytorch_ie.models.interface import RequiresModelNameOrPath, RequiresNumClasses
 from pytorch_ie.models.modules.mlp import MLP
 
 ModelInputType: TypeAlias = BatchEncoding
@@ -29,7 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 @PyTorchIEModel.register()
-class TransformerSpanClassificationModel(PyTorchIEModel):
+class TransformerSpanClassificationModel(
+    PyTorchIEModel, RequiresModelNameOrPath, RequiresNumClasses
+):
     def __init__(
         self,
         model_name_or_path: str,

--- a/src/pytorch_ie/models/transformer_text_classification.py
+++ b/src/pytorch_ie/models/transformer_text_classification.py
@@ -38,6 +38,7 @@ class TransformerTextClassificationModel(
         learning_rate: float = 1e-5,
         task_learning_rate: float = 1e-4,
         warmup_proportion: float = 0.1,
+        freeze_model: bool = False,
         multi_label: bool = False,
         t_total: Optional[int] = None,
         **kwargs,
@@ -60,6 +61,10 @@ class TransformerTextClassificationModel(
             self.model = AutoModel.from_config(config=config)
         else:
             self.model = AutoModel.from_pretrained(model_name_or_path, config=config)
+
+        if freeze_model:
+            for param in self.model.parameters():
+                param.requires_grad = False
 
         if tokenizer_vocab_size is not None:
             self.model.resize_token_embeddings(tokenizer_vocab_size)

--- a/src/pytorch_ie/models/transformer_token_classification.py
+++ b/src/pytorch_ie/models/transformer_token_classification.py
@@ -7,6 +7,7 @@ from transformers import AutoConfig, AutoModelForTokenClassification, BatchEncod
 from typing_extensions import TypeAlias
 
 from pytorch_ie.core import PyTorchIEModel
+from pytorch_ie.models.interface import RequiresModelNameOrPath, RequiresNumClasses
 
 ModelInputType: TypeAlias = BatchEncoding
 ModelOutputType: TypeAlias = Dict[str, Any]
@@ -23,7 +24,9 @@ TEST = "test"
 
 
 @PyTorchIEModel.register()
-class TransformerTokenClassificationModel(PyTorchIEModel):
+class TransformerTokenClassificationModel(
+    PyTorchIEModel, RequiresModelNameOrPath, RequiresNumClasses
+):
     def __init__(
         self,
         model_name_or_path: str,

--- a/src/pytorch_ie/taskmodules/interface.py
+++ b/src/pytorch_ie/taskmodules/interface.py
@@ -1,0 +1,2 @@
+class ChangesTokenizerVocabSize:
+    pass

--- a/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
@@ -27,6 +27,7 @@ from pytorch_ie.annotations import (
 from pytorch_ie.core import AnnotationList, Document, TaskEncoding, TaskModule
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models.transformer_text_classification import ModelOutputType, ModelStepInputType
+from pytorch_ie.taskmodules.interface import ChangesTokenizerVocabSize
 from pytorch_ie.utils.span import get_token_slice, is_contained_in
 from pytorch_ie.utils.window import get_window_around_slice
 
@@ -109,7 +110,7 @@ class RelationArgument:
 
 
 @TaskModule.register()
-class TransformerRETextClassificationTaskModule(TaskModuleType):
+class TransformerRETextClassificationTaskModule(TaskModuleType, ChangesTokenizerVocabSize):
     """Marker based relation extraction. This taskmodule prepares the input token ids in such a way
     that before and after the candidate head and tail entities special marker tokens are inserted.
     Then, the modified token ids can be simply passed into a transformer based text classifier


### PR DESCRIPTION
These classes don't do anything on its own, but can be used to signal some needs / functionality in downstream projects / scripts.

Model interface classes and usage:
 - `RequiresModelNameOrPath` (all models): `TransformerSeq2SeqModel`, `TransformerSpanClassificationModel`, `TransformerTextClassificationModel`, `TransformerTokenClassificationModel`
 - `RequiresNumClasses`: `TransformerSpanClassificationModel`, `TransformerTextClassificationModel`, `TransformerTokenClassificationModel`

Taskmodule interface classes and usage:
 - `ChangesTokenizerVocabSize`: `TransformerRETextClassificationTaskModule`