### PR TITLE
add document converters

### DIFF
--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -12,6 +12,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Type,
     TypeVar,
     Union,
     overload,
@@ -158,10 +159,15 @@ class TaskModule(
     ],
 ):
     PREPARED_ATTRIBUTES: List[str] = []
+    DOCUMENT_TYPE: Optional[Type[DocumentType]] = None
 
     def __init__(self, encode_document_batch_size: Optional[int] = None, **kwargs):
         super().__init__(**kwargs)
         self.encode_document_batch_size = encode_document_batch_size
+
+    @property
+    def document_type(self) -> Optional[Type[DocumentType]]:
+        return self.DOCUMENT_TYPE
 
     @property
     def is_prepared(self):

--- a/src/pytorch_ie/data/builder.py
+++ b/src/pytorch_ie/data/builder.py
@@ -59,9 +59,7 @@ class PieDatasetBuilder(hf_datasets.builder.DatasetBuilder):
     def __init__(
         self,
         base_dataset_kwargs: Optional[Dict[str, Any]] = None,
-        target_document_type: Optional[
-            Union[Type[Document], str, List[Type[Document]], List[str]]
-        ] = None,
+        target_document_type: Optional[Union[Type[Document], str]] = None,
         document_converter: Optional[Union[Callable[..., Document], Dict[str, str]]] = None,
         **kwargs,
     ):
@@ -118,13 +116,11 @@ class PieDatasetBuilder(hf_datasets.builder.DatasetBuilder):
 
         super().__init__(**kwargs)
 
-        self.target_document_type: Optional[Union[Type[Document], List[Type[Document]]]]
+        self.target_document_type: Optional[Type[Document]]
         if target_document_type is None:
             self.target_document_type = None
         elif isinstance(target_document_type, str):
             self.target_document_type = resolve_target(target_document_type)  # type: ignore
-        elif isinstance(target_document_type, list):
-            self.target_document_type = [resolve_target(t) for t in target_document_type]  # type: ignore
         elif issubclass(target_document_type, Document):
             self.target_document_type = target_document_type
         else:

--- a/src/pytorch_ie/data/builder.py
+++ b/src/pytorch_ie/data/builder.py
@@ -60,7 +60,7 @@ class PieDatasetBuilder(hf_datasets.builder.DatasetBuilder):
         self,
         base_dataset_kwargs: Optional[Dict[str, Any]] = None,
         document_converters: Optional[
-            Dict[Union[Type[Document], str], Union[Callable[..., Document], Dict[str, str]]]
+            Dict[Union[Type[Document], str], Union[Callable[..., Document], Dict[str, str], str]]
         ] = None,
         **kwargs,
     ):
@@ -119,9 +119,15 @@ class PieDatasetBuilder(hf_datasets.builder.DatasetBuilder):
 
         self.document_converters = dict(self.DOCUMENT_CONVERTERS)
         if document_converters is not None:
-            for document_type_or_str, document_converter in document_converters.items():
+            for document_type_or_str, document_converter_or_str in document_converters.items():
                 document_type = resolve_target(document_type_or_str)
                 if isinstance(document_type, type) and issubclass(document_type, Document):
+                    document_converter: Union[Callable[..., Any], dict[str, str]]
+                    if isinstance(document_converter_or_str, str):
+                        document_converter = resolve_target(document_converter_or_str)
+                    else:
+                        document_converter = document_converter_or_str
+
                     self.document_converters[document_type] = document_converter
                 else:
                     raise TypeError(

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -481,5 +481,5 @@ def get_pie_dataset_type(
         return IterableDataset
     else:
         raise TypeError(
-            f"the dataset must be of type Dataset or IterableDataset, but is {type(hf_dataset)}"
+            f"the dataset must be of type Dataset or IterableDataset, but is of type {type(hf_dataset)}"
         )

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -478,16 +478,14 @@ class IterableDataset(datasets.IterableDataset):
     ) -> None:
         self.document_converters[document_type] = converter
 
-    def convert_to(
+    def to_document_type(
         self,
-        document_type: Optional[Type[Document]] = None,
-        converter: Optional[Union[Callable[..., Document], Dict[str, str]]] = None,
+        document_type: Type[Document],
         **kwargs,
     ) -> "IterableDataset":
         return dataset_to_document_type(
             dataset=self,
             document_type=document_type,
-            converter=converter,
             **kwargs,
         )
 

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -194,7 +194,7 @@ class Dataset(datasets.Dataset):
     def convert_to(self, document_type: Type[D], **kwargs) -> "Dataset":
         document_converter = self.document_converters.get(document_type, None)
         if document_converter is not None and callable(document_converter):
-            return self.map(
+            result = self.map(
                 function=document_converter,
                 result_document_type=document_type,
                 fn_kwargs=kwargs,
@@ -206,9 +206,12 @@ class Dataset(datasets.Dataset):
                     f"{[dt.__name__ for dt in self.document_converters]}. "
                     "Perform a simple cast instead of a conversion."
                 )
-            return self.cast_document_type(
+            result = self.cast_document_type(
                 new_document_type=document_type, field_mapping=document_converter, **kwargs
             )
+        # remove the document converters because they are not valid anymore
+        result.document_converters = None
+        return result
 
     def map(
         self,
@@ -374,7 +377,7 @@ class IterableDataset(datasets.IterableDataset):
     def convert_to(self, document_type: Type[D], **kwargs) -> "IterableDataset":
         document_converter = self.document_converters.get(document_type, None)
         if document_converter is not None and callable(document_converter):
-            return self.map(
+            result = self.map(
                 function=document_converter,
                 result_document_type=document_type,
                 fn_kwargs=kwargs,
@@ -386,9 +389,12 @@ class IterableDataset(datasets.IterableDataset):
                     f"{[dt.__name__ for dt in self.document_converters]}. "
                     "Perform a simple cast instead of a conversion."
                 )
-            return self.cast_document_type(
+            result = self.cast_document_type(
                 new_document_type=document_type, field_mapping=document_converter, **kwargs
             )
+        # remove the document converters because they are not valid anymore
+        result.document_converters = None
+        return result
 
     def map(  # type: ignore
         self,

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -193,20 +193,21 @@ class Dataset(datasets.Dataset):
 
     def convert_to(self, document_type: Type[D], **kwargs) -> "Dataset":
         document_converter = self.document_converters.get(document_type, None)
-        if document_converter is None or isinstance(document_converter, dict):
-            logger.warning(
-                f"document_type {document_type.__name__} not in document_converters: "
-                f"{[dt.__name__ for dt in self.document_converters]}. "
-                "Perform a simple cast instead of a conversion."
-            )
-            return self.cast_document_type(
-                new_document_type=document_type, field_mapping=document_converter, **kwargs
-            )
-        else:
+        if document_converter is not None and callable(document_converter):
             return self.map(
                 function=document_converter,
                 result_document_type=document_type,
                 fn_kwargs=kwargs,
+            )
+        else:
+            if document_converter is None:
+                logger.warning(
+                    f"document_type {document_type.__name__} is not in document_converters: "
+                    f"{[dt.__name__ for dt in self.document_converters]}. "
+                    "Perform a simple cast instead of a conversion."
+                )
+            return self.cast_document_type(
+                new_document_type=document_type, field_mapping=document_converter, **kwargs
             )
 
     def map(
@@ -372,20 +373,21 @@ class IterableDataset(datasets.IterableDataset):
 
     def convert_to(self, document_type: Type[D], **kwargs) -> "IterableDataset":
         document_converter = self.document_converters.get(document_type, None)
-        if document_converter is None or isinstance(document_converter, dict):
-            logger.warning(
-                f"document_type {document_type.__name__} not in document_converters: "
-                f"{[dt.__name__ for dt in self.document_converters]}. "
-                "Perform a simple cast instead of a conversion."
-            )
-            return self.cast_document_type(
-                new_document_type=document_type, field_mapping=document_converter, **kwargs
-            )
-        else:
+        if document_converter is not None and callable(document_converter):
             return self.map(
                 function=document_converter,
                 result_document_type=document_type,
                 fn_kwargs=kwargs,
+            )
+        else:
+            if document_converter is None:
+                logger.warning(
+                    f"document_type {document_type.__name__} is not in document_converters: "
+                    f"{[dt.__name__ for dt in self.document_converters]}. "
+                    "Perform a simple cast instead of a conversion."
+                )
+            return self.cast_document_type(
+                new_document_type=document_type, field_mapping=document_converter, **kwargs
             )
 
     def map(  # type: ignore

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -149,7 +149,7 @@ def _infer_document_type_from_function_return(
 
 
 D = TypeVar("D", bound=Document)
-DocumentTypeToConverterOrFieldMappingType = Dict[Type[D], Union[Callable[..., D], Dict[str, str]]]
+DocumentConvertersType = Dict[Type[D], Union[Callable[..., D], Dict[str, str]]]
 
 
 def get_best_dataset_converter_with_types(
@@ -198,7 +198,7 @@ def get_best_dataset_converter_with_types(
 
 
 @overload
-def convert_dataset_to(
+def dataset_to_document_type(
     dataset: "Dataset",
     document_type: Optional[Type[Document]] = None,
     converter: Optional[Union[Callable[..., Document], Dict[str, str]]] = None,
@@ -208,7 +208,7 @@ def convert_dataset_to(
 
 
 @overload
-def convert_dataset_to(
+def dataset_to_document_type(
     dataset: "IterableDataset",
     document_type: Optional[Type[Document]] = None,
     converter: Optional[Union[Callable[..., Document], Dict[str, str]]] = None,
@@ -217,7 +217,7 @@ def convert_dataset_to(
     ...
 
 
-def convert_dataset_to(
+def dataset_to_document_type(
     dataset: Union["IterableDataset", "Dataset"],
     document_type: Optional[Type[Document]] = None,
     converter: Optional[Union[Callable[..., Document], Dict[str, str]]] = None,
@@ -256,7 +256,7 @@ class Dataset(datasets.Dataset):
         split: Optional[datasets.NamedSplit] = None,
         indices_table: Optional[datasets.table.Table] = None,
         fingerprint: Optional[str] = None,
-        document_converters: Optional[DocumentTypeToConverterOrFieldMappingType] = None,
+        document_converters: Optional[DocumentConvertersType] = None,
     ):
         super().__init__(
             arrow_table=arrow_table,
@@ -285,7 +285,7 @@ class Dataset(datasets.Dataset):
         cls,
         dataset: datasets.Dataset,
         document_type: Type[Document],
-        document_converters: Optional[DocumentTypeToConverterOrFieldMappingType] = None,
+        document_converters: Optional[DocumentConvertersType] = None,
     ) -> "Dataset":
         document_dataset = cls(
             document_type=document_type,
@@ -306,16 +306,14 @@ class Dataset(datasets.Dataset):
     ) -> None:
         self.document_converters[document_type] = converter
 
-    def convert_to(
+    def to_document_type(
         self,
-        document_type: Optional[Type[Document]] = None,
-        converter: Optional[Union[Callable[..., Document], Dict[str, str]]] = None,
+        document_type: Type[Document],
         **kwargs,
     ) -> "Dataset":
-        return convert_dataset_to(
+        return dataset_to_document_type(
             dataset=self,
             document_type=document_type,
-            converter=converter,
             **kwargs,
         )
 
@@ -428,7 +426,7 @@ class IterableDataset(datasets.IterableDataset):
         self,
         document_type: Type[Document],
         hidden_columns: Optional[Set[str]] = None,
-        document_converters: Optional[DocumentTypeToConverterOrFieldMappingType] = None,
+        document_converters: Optional[DocumentConvertersType] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -461,7 +459,7 @@ class IterableDataset(datasets.IterableDataset):
         dataset: datasets.IterableDataset,
         document_type: Type[Document],
         hidden_columns: Optional[Set[str]] = None,
-        document_converters: Optional[DocumentTypeToConverterOrFieldMappingType] = None,
+        document_converters: Optional[DocumentConvertersType] = None,
     ) -> "IterableDataset":
         dataset = cls(
             document_type=document_type,
@@ -486,7 +484,7 @@ class IterableDataset(datasets.IterableDataset):
         converter: Optional[Union[Callable[..., Document], Dict[str, str]]] = None,
         **kwargs,
     ) -> "IterableDataset":
-        return convert_dataset_to(
+        return dataset_to_document_type(
             dataset=self,
             document_type=document_type,
             converter=converter,

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -199,6 +199,7 @@ def dataset_to_document_type(
 
     # do nothing if the document type is already the requested type
     if document_type == dataset.document_type:
+        logger.info(f"The dataset has already the requested document type {document_type}.")
         return dataset
 
     converter, requested_type, registered_type = _get_best_dataset_converter_with_types(

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -143,6 +143,7 @@ def _infer_document_type_from_function_return(
                 logger.warning(
                     f"the return type annotation of the function used with map is not a subclass of Document"
                 )
+                return None
         return return_signature
     return None
 

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -210,7 +210,7 @@ class Dataset(datasets.Dataset):
                 new_document_type=document_type, field_mapping=document_converter, **kwargs
             )
         # remove the document converters because they are not valid anymore
-        result.document_converters = None
+        result.document_converters = {}
         return result
 
     def map(
@@ -393,7 +393,7 @@ class IterableDataset(datasets.IterableDataset):
                 new_document_type=document_type, field_mapping=document_converter, **kwargs
             )
         # remove the document converters because they are not valid anymore
-        result.document_converters = None
+        result.document_converters = {}
         return result
 
     def map(  # type: ignore

--- a/src/pytorch_ie/data/dataset_dict.py
+++ b/src/pytorch_ie/data/dataset_dict.py
@@ -182,7 +182,7 @@ class DatasetDict(datasets.DatasetDict):
                 and issubclass(resolved_document_type, Document)
             ):
                 raise TypeError(
-                    f"document_type must be or resolv to a subclass of Document, but is {document_type}"
+                    f"document_type must be or resolve to a subclass of Document, but is '{document_type}'"
                 )
 
         resolved_converter: Union[Callable[..., Any], dict[str, str]]

--- a/src/pytorch_ie/data/dataset_dict.py
+++ b/src/pytorch_ie/data/dataset_dict.py
@@ -7,12 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, SupportsIndex, Type, Typ
 import datasets
 
 from pytorch_ie.core import Document
-from pytorch_ie.data.dataset import (
-    Dataset,
-    IterableDataset,
-    _infer_document_type_from_function_return,
-    get_pie_dataset_type,
-)
+from pytorch_ie.data.dataset import Dataset, IterableDataset, get_pie_dataset_type
 from pytorch_ie.utils.hydra import resolve_target
 
 from .common import (

--- a/src/pytorch_ie/data/dataset_dict.py
+++ b/src/pytorch_ie/data/dataset_dict.py
@@ -231,6 +231,10 @@ class DatasetDict(datasets.DatasetDict):
                 f"but got {document_type}."
             )
 
+        if resolved_document_type == self.document_type:
+            logger.info(f"The dataset has already the requested document type {document_type}.")
+            return self
+
         result = type(self)(
             {
                 name: ds.to_document_type(document_type=resolved_document_type, **kwargs)

--- a/src/pytorch_ie/data/dataset_dict.py
+++ b/src/pytorch_ie/data/dataset_dict.py
@@ -222,7 +222,7 @@ class DatasetDict(datasets.DatasetDict):
 
         result = type(self)(
             {
-                name: ds.dataset_to_document_type(document_type=resolved_document_type, **kwargs)
+                name: ds.to_document_type(document_type=resolved_document_type, **kwargs)
                 for name, ds in self.items()
             }
         )

--- a/src/pytorch_ie/data/dataset_dict.py
+++ b/src/pytorch_ie/data/dataset_dict.py
@@ -192,9 +192,7 @@ class DatasetDict(datasets.DatasetDict):
 
     def convert_to(
         self,
-        document_type: Optional[
-            Union[Type[Document], str, List[Type[Document]], List[str]]
-        ] = None,
+        document_type: Optional[Union[Type[Document], str]] = None,
         converter: Optional[Union[Callable[..., Document], Dict[str, str]]] = None,
         **kwargs,
     ) -> "DatasetDict":
@@ -209,13 +207,11 @@ class DatasetDict(datasets.DatasetDict):
                 provided, this converter is used instead of the registered converters.
         """
 
-        target_document_type: Optional[Union[Type[Document], List[Type[Document]]]]
+        target_document_type: Optional[Union[Type[Document], str]]
         if document_type is None:
             target_document_type = None
         elif isinstance(document_type, str):
             target_document_type = resolve_target(document_type)  # type: ignore
-        elif isinstance(document_type, list):
-            target_document_type = [resolve_target(t) for t in document_type]  # type: ignore
         elif issubclass(document_type, Document):
             target_document_type = document_type
         else:

--- a/src/pytorch_ie/documents.py
+++ b/src/pytorch_ie/documents.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from typing_extensions import TypeAlias
 
-from pytorch_ie.annotations import Attribute, BinaryRelation, LabeledSpan, Span
+from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
 from pytorch_ie.core import AnnotationList, Document, annotation_field
 
 

--- a/src/pytorch_ie/documents.py
+++ b/src/pytorch_ie/documents.py
@@ -38,19 +38,32 @@ TextDocument: TypeAlias = TextBasedDocument
 
 
 @dataclasses.dataclass
-class TextDocumentWithEntitiesAndRelations(TextBasedDocument):
+class TextDocumentWithEntities(TextBasedDocument):
     entities: AnnotationList[Span] = annotation_field(target="text")
+
+
+@dataclasses.dataclass
+class TextDocumentWithEntitiesAndRelations(TextDocumentWithEntities):
     relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+
+@dataclasses.dataclass
+class TextDocumentWithEntitiesRelationsAndLabeledPartitions(TextDocumentWithEntitiesAndRelations):
+    partitions: AnnotationList[LabeledSpan] = annotation_field(target="text")
 
 
 @dataclasses.dataclass
 class TextDocumentWithLabeledEntitiesAndRelations(TextBasedDocument):
     entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledEntities(TextDocumentWithLabeledEntitiesAndRelations):
     relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
 
 
 @dataclasses.dataclass
-class TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions(TextBasedDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+class TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions(
+    TextDocumentWithLabeledEntities
+):
     partitions: AnnotationList[LabeledSpan] = annotation_field(target="text")

--- a/src/pytorch_ie/documents.py
+++ b/src/pytorch_ie/documents.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from typing_extensions import TypeAlias
 
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
+from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, MultiLabel, Span
 from pytorch_ie.core import AnnotationList, Document, annotation_field
 
 
@@ -38,32 +38,61 @@ TextDocument: TypeAlias = TextBasedDocument
 
 
 @dataclasses.dataclass
-class TextDocumentWithEntities(TextBasedDocument):
-    entities: AnnotationList[Span] = annotation_field(target="text")
+class DocumentWithLabel(Document):
+    label: AnnotationList[Label] = annotation_field()
 
 
 @dataclasses.dataclass
-class TextDocumentWithEntitiesAndRelations(TextDocumentWithEntities):
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+class DocumentWithMultiLabel(Document):
+    label: AnnotationList[MultiLabel] = annotation_field()
 
 
 @dataclasses.dataclass
-class TextDocumentWithEntitiesRelationsAndLabeledPartitions(TextDocumentWithEntitiesAndRelations):
+class TextDocumentWithLabel(DocumentWithLabel, TextBasedDocument):
+    pass
+
+
+@dataclasses.dataclass
+class TextDocumentWithMultiLabel(DocumentWithMultiLabel, TextBasedDocument):
+    pass
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledPartitions(TextBasedDocument):
     partitions: AnnotationList[LabeledSpan] = annotation_field(target="text")
 
 
 @dataclasses.dataclass
-class TextDocumentWithLabeledEntitiesAndRelations(TextBasedDocument):
+class TextDocumentWithSentences(TextBasedDocument):
+    sentences: AnnotationList[Span] = annotation_field(target="text")
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledEntities(TextBasedDocument):
     entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
 
 
 @dataclasses.dataclass
-class TextDocumentWithLabeledEntities(TextDocumentWithLabeledEntitiesAndRelations):
+class TextDocumentWithLabeledEntitiesAndLabeledPartitions(
+    TextDocumentWithLabeledEntities, TextDocumentWithLabeledPartitions
+):
+    pass
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledEntitiesAndSentences(
+    TextDocumentWithLabeledEntities, TextDocumentWithSentences
+):
+    pass
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledEntitiesAndRelations(TextDocumentWithLabeledEntities):
     relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
 
 
 @dataclasses.dataclass
 class TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions(
-    TextDocumentWithLabeledEntities
+    TextDocumentWithLabeledEntitiesAndRelations, TextDocumentWithLabeledPartitions
 ):
-    partitions: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    pass

--- a/src/pytorch_ie/documents.py
+++ b/src/pytorch_ie/documents.py
@@ -68,6 +68,11 @@ class TextDocumentWithSentences(TextBasedDocument):
 
 
 @dataclasses.dataclass
+class TextDocumentWithEntities(TextBasedDocument):
+    entities: AnnotationList[Span] = annotation_field(target="text")
+
+
+@dataclasses.dataclass
 class TextDocumentWithLabeledEntities(TextBasedDocument):
     entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
 
@@ -94,5 +99,17 @@ class TextDocumentWithLabeledEntitiesAndRelations(TextDocumentWithLabeledEntitie
 @dataclasses.dataclass
 class TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions(
     TextDocumentWithLabeledEntitiesAndRelations, TextDocumentWithLabeledPartitions
+):
+    pass
+
+
+@dataclasses.dataclass
+class TextDocumentWithEntitiesAndRelations(TextDocumentWithEntities):
+    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+
+@dataclasses.dataclass
+class TextDocumentWithEntitiesRelationsAndLabeledPartitions(
+    TextDocumentWithEntitiesAndRelations, TextDocumentWithLabeledPartitions
 ):
     pass

--- a/src/pytorch_ie/documents.py
+++ b/src/pytorch_ie/documents.py
@@ -3,7 +3,8 @@ from typing import Any, Dict, Optional, Tuple
 
 from typing_extensions import TypeAlias
 
-from pytorch_ie.core import Document
+from pytorch_ie.annotations import Attribute, BinaryRelation, LabeledSpan, Span
+from pytorch_ie.core import AnnotationList, Document, annotation_field
 
 
 @dataclasses.dataclass
@@ -34,3 +35,22 @@ class TokenBasedDocument(WithMetadata, WithTokens, Document):
 
 # backwards compatibility
 TextDocument: TypeAlias = TextBasedDocument
+
+
+@dataclasses.dataclass
+class TextDocumentWithEntitiesAndRelations(TextBasedDocument):
+    entities: AnnotationList[Span] = annotation_field(target="text")
+    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledEntitiesAndRelations(TextBasedDocument):
+    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions(TextBasedDocument):
+    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    partitions: AnnotationList[LabeledSpan] = annotation_field(target="text")

--- a/src/pytorch_ie/taskmodules/simple_transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/simple_transformer_text_classification.py
@@ -18,15 +18,11 @@ from transformers.tokenization_utils_base import TruncationStrategy
 from typing_extensions import TypeAlias
 
 from pytorch_ie.annotations import Label
-from pytorch_ie.core import AnnotationList, TaskEncoding, TaskModule, annotation_field
-from pytorch_ie.documents import TextDocument
+from pytorch_ie.core import TaskEncoding, TaskModule
+from pytorch_ie.documents import TextDocumentWithLabel
 from pytorch_ie.models.transformer_text_classification import ModelOutputType, ModelStepInputType
 
 logger = logging.getLogger(__name__)
-
-
-class TextDocumentWithLabel(TextDocument):
-    label: AnnotationList[Label] = annotation_field()
 
 
 class TaskOutput(TypedDict, total=False):
@@ -59,6 +55,7 @@ class SimpleTransformerTextClassificationTaskModule(TaskModuleType):
     # If these attributes are set, the taskmodule is considered as prepared. They should be calculated
     # within _prepare() and are dumped automatically when saving the taskmodule with save_pretrained().
     PREPARED_ATTRIBUTES = ["label_to_id"]
+    DOCUMENT_TYPE = TextDocumentWithLabel
 
     def __init__(
         self,

--- a/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
@@ -8,7 +8,19 @@ workflow:
 """
 
 import logging
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, TypedDict, Union
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    TypedDict,
+    Union,
+)
 
 import numpy as np
 import torch
@@ -25,7 +37,11 @@ from pytorch_ie.annotations import (
     Span,
 )
 from pytorch_ie.core import AnnotationList, Document, TaskEncoding, TaskModule
-from pytorch_ie.documents import TextDocument
+from pytorch_ie.documents import (
+    TextDocument,
+    TextDocumentWithLabeledEntitiesAndRelations,
+    TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions,
+)
 from pytorch_ie.models.transformer_text_classification import ModelOutputType, ModelStepInputType
 from pytorch_ie.taskmodules.interface import ChangesTokenizerVocabSize
 from pytorch_ie.utils.span import get_token_slice, is_contained_in
@@ -196,6 +212,13 @@ class TransformerRETextClassificationTaskModule(TaskModuleType, ChangesTokenizer
         self.argument_markers = None
 
         self._logged_examples_counter = 0
+
+    @property
+    def document_type(self) -> Optional[Type[TextDocument]]:
+        if self.partition_annotation is not None:
+            return TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions
+        else:
+            return TextDocumentWithLabeledEntitiesAndRelations
 
     def get_relation_layer(self, document: Document) -> AnnotationList[BinaryRelation]:
         return document[self.relation_annotation]

--- a/src/pytorch_ie/taskmodules/transformer_seq2seq.py
+++ b/src/pytorch_ie/taskmodules/transformer_seq2seq.py
@@ -16,9 +16,9 @@ from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import TruncationStrategy
 from typing_extensions import TypeAlias
 
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
+from pytorch_ie.annotations import BinaryRelation, LabeledSpan
 from pytorch_ie.core import Annotation, TaskEncoding, TaskModule
-from pytorch_ie.documents import TextDocument
+from pytorch_ie.documents import TextDocument, TextDocumentWithLabeledEntitiesAndRelations
 from pytorch_ie.models.transformer_seq2seq import ModelOutputType, ModelStepInputType
 
 InputEncodingType: TypeAlias = Dict[str, Sequence[int]]
@@ -41,6 +41,9 @@ logger = logging.getLogger(__name__)
 
 @TaskModule.register()
 class TransformerSeq2SeqTaskModule(TaskModuleType):
+
+    DOCUMENT_TYPE = TextDocumentWithLabeledEntitiesAndRelations
+
     def __init__(
         self,
         tokenizer_name_or_path: str,

--- a/src/pytorch_ie/taskmodules/transformer_span_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_span_classification.py
@@ -20,7 +20,12 @@ from typing_extensions import TypeAlias
 
 from pytorch_ie.annotations import LabeledSpan, MultiLabeledSpan, Span
 from pytorch_ie.core import TaskEncoding, TaskModule
-from pytorch_ie.documents import TextDocument
+from pytorch_ie.documents import (
+    TextDocument,
+    TextDocumentWithLabeledEntities,
+    TextDocumentWithLabeledEntitiesAndLabeledPartitions,
+    TextDocumentWithLabeledEntitiesAndSentences,
+)
 from pytorch_ie.models.transformer_span_classification import ModelOutputType, ModelStepInputType
 
 InputEncodingType: TypeAlias = BatchEncoding
@@ -83,6 +88,13 @@ class TransformerSpanClassificationTaskModule(TaskModuleType):
         self.pad_to_multiple_of = pad_to_multiple_of
         self.label_pad_token_id = label_pad_token_id
         self.multi_label = multi_label
+
+    @property
+    def document_type(self) -> TypeAlias:
+        if self.single_sentence:
+            return TextDocumentWithLabeledEntitiesAndSentences
+        else:
+            return TextDocumentWithLabeledEntities
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config()

--- a/src/pytorch_ie/taskmodules/transformer_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_text_classification.py
@@ -16,6 +16,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Type,
     TypedDict,
     Union,
 )
@@ -29,7 +30,7 @@ from typing_extensions import TypeAlias
 
 from pytorch_ie.annotations import Label, MultiLabel
 from pytorch_ie.core import TaskEncoding, TaskModule
-from pytorch_ie.documents import TextDocument
+from pytorch_ie.documents import TextDocument, TextDocumentWithLabel, TextDocumentWithMultiLabel
 from pytorch_ie.models.transformer_text_classification import ModelOutputType, ModelStepInputType
 
 InputEncodingType: TypeAlias = MutableMapping[str, Any]
@@ -101,6 +102,13 @@ class TransformerTextClassificationTaskModule(TaskModuleType):
         self.max_length = max_length
         self.pad_to_multiple_of = pad_to_multiple_of
         self.multi_label = multi_label
+
+    @property
+    def document_type(self) -> Type[TextDocument]:
+        if self.multi_label:
+            return TextDocumentWithMultiLabel
+        else:
+            return TextDocumentWithLabel
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config()

--- a/src/pytorch_ie/taskmodules/transformer_token_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_token_classification.py
@@ -9,7 +9,7 @@ workflow:
 
 import copy
 import logging
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union
 
 import torch
 import torch.nn.functional as F
@@ -20,7 +20,11 @@ from typing_extensions import TypeAlias
 
 from pytorch_ie.annotations import LabeledSpan, Span
 from pytorch_ie.core import TaskEncoding, TaskModule
-from pytorch_ie.documents import TextDocument
+from pytorch_ie.documents import (
+    TextDocument,
+    TextDocumentWithLabeledEntities,
+    TextDocumentWithLabeledEntitiesAndLabeledPartitions,
+)
 from pytorch_ie.models.transformer_token_classification import ModelOutputType, ModelStepInputType
 from pytorch_ie.utils.span import (
     bio_tags_to_spans,
@@ -89,6 +93,13 @@ class TransformerTokenClassificationTaskModule(TaskModuleType):
         self.window_overlap = window_overlap
         self.show_statistics = show_statistics
         self.include_ill_formed_predictions = include_ill_formed_predictions
+
+    @property
+    def document_type(self) -> Type[TextDocument]:
+        if self.partition_annotation is not None:
+            return TextDocumentWithLabeledEntitiesAndLabeledPartitions
+        else:
+            return TextDocumentWithLabeledEntities
 
     def _config(self) -> Dict[str, Any]:
         config = super()._config()

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -314,36 +314,146 @@ def test_get_pie_dataset_type(json_dataset, iterable_json_dataset):
     )
 
 
-def test_register_document_converter_function(maybe_iterable_dataset):
+@dataclass
+class TestDocumentWithLabel(TextDocument):
+    label: AnnotationList[Label] = annotation_field()
+
+
+def convert_to_document_with_label(document: TestDocument) -> TestDocumentWithLabel:
+    result = TestDocumentWithLabel(text=document.text)
+    result.label.append(Label(label="label"))
+    return result
+
+
+@pytest.fixture
+def dataset_with_converter_functions(maybe_iterable_dataset) -> Union[Dataset, IterableDataset]:
     train_dataset: Union[Dataset, IterableDataset] = maybe_iterable_dataset["train"]
     assert len(train_dataset.document_converters) == 0
 
-    class TestDocumentWithLabel(TextDocument):
-        label: AnnotationList[Label] = annotation_field()
-
-    def convert_to_text_document(document: TestDocument) -> TestDocumentWithLabel:
-        result = TestDocumentWithLabel(text=document.text)
-        result.label.append(Label(label="label"))
-        return result
-
-    train_dataset.register_document_converter(convert_to_text_document)
-
-    assert len(train_dataset.document_converters) == 1
-    assert TestDocumentWithLabel in train_dataset.document_converters
-    assert train_dataset.document_converters[TestDocumentWithLabel] == convert_to_text_document
+    train_dataset.register_document_converter(convert_to_document_with_label)
+    return train_dataset
 
 
-def test_register_document_converter_mapping(maybe_iterable_dataset):
-    train_dataset: Union[Dataset, IterableDataset] = maybe_iterable_dataset["train"]
-    assert len(train_dataset.document_converters) == 0
+def test_register_document_converter_function(dataset_with_converter_functions):
 
-    class TestDocumentWithLabeledSpans(TextDocument):
-        spans: AnnotationList[LabeledSpan] = annotation_field(target="text")
-
-    train_dataset.register_document_converter(
-        converter={"entities": "spans"}, document_type=TestDocumentWithLabeledSpans
+    assert len(dataset_with_converter_functions.document_converters) == 1
+    assert TestDocumentWithLabel in dataset_with_converter_functions.document_converters
+    assert (
+        dataset_with_converter_functions.document_converters[TestDocumentWithLabel]
+        == convert_to_document_with_label
     )
 
-    assert len(train_dataset.document_converters) == 1
-    assert TestDocumentWithLabeledSpans in train_dataset.document_converters
-    assert train_dataset.document_converters[TestDocumentWithLabeledSpans] == {"entities": "spans"}
+
+@dataclass
+class TestDocumentWithLabeledSpans(TextDocument):
+    spans: AnnotationList[LabeledSpan] = annotation_field(target="text")
+
+
+@pytest.fixture
+def dataset_with_converter_mapping(maybe_iterable_dataset) -> Union[Dataset, IterableDataset]:
+    train_dataset: Union[Dataset, IterableDataset] = maybe_iterable_dataset["train"]
+    assert len(train_dataset.document_converters) == 0
+
+    field_mapping = {"entities": "spans"}
+    train_dataset.register_document_converter(
+        converter=field_mapping, document_type=TestDocumentWithLabeledSpans
+    )
+    return train_dataset
+
+
+def test_register_document_converter_mapping(dataset_with_converter_mapping):
+    assert len(dataset_with_converter_mapping.document_converters) == 1
+    assert TestDocumentWithLabeledSpans in dataset_with_converter_mapping.document_converters
+    assert dataset_with_converter_mapping.document_converters[TestDocumentWithLabeledSpans] == {
+        "entities": "spans"
+    }
+
+
+def test_to_document_type_function(dataset_with_converter_functions):
+    assert dataset_with_converter_functions.document_type == TestDocument
+    converted_dataset = dataset_with_converter_functions.to_document_type(TestDocumentWithLabel)
+    assert converted_dataset.document_type == TestDocumentWithLabel
+
+    assert len(converted_dataset.document_converters) == 0
+    for doc in converted_dataset:
+        assert isinstance(doc, TestDocumentWithLabel)
+        assert len(doc.label) == 1
+        assert doc.label[0].label == "label"
+
+
+def test_to_document_type_mapping(dataset_with_converter_mapping):
+    assert dataset_with_converter_mapping.document_type == TestDocument
+    converted_dataset = dataset_with_converter_mapping.to_document_type(
+        TestDocumentWithLabeledSpans
+    )
+    assert converted_dataset.document_type == TestDocumentWithLabeledSpans
+
+    assert len(converted_dataset.document_converters) == 0
+    for doc_converted, doc in zip(converted_dataset, dataset_with_converter_mapping):
+        assert isinstance(doc, TestDocument)
+        assert isinstance(doc_converted, TestDocumentWithLabeledSpans)
+        assert "spans" in doc_converted
+        assert doc_converted.spans == doc.entities
+        original_annotation_field_names = {f.name for f in doc.annotation_fields()}
+        assert original_annotation_field_names == {"sentences", "entities", "relations"}
+        for annotation_field_name in original_annotation_field_names:
+            assert annotation_field_name not in doc_converted
+
+
+def test_to_document_type_noop(maybe_iterable_dataset):
+    train_dataset: Union[Dataset, IterableDataset] = maybe_iterable_dataset["train"]
+    assert len(train_dataset.document_converters) == 0
+    train_dataset.register_document_converter(
+        convert_to_document_with_label, document_type=TestDocument
+    )
+    assert train_dataset.document_type == TestDocument
+    converted_dataset = train_dataset.to_document_type(TestDocument)
+    # the conversion should be a noop
+    assert converted_dataset.document_type == TestDocument
+    assert converted_dataset == train_dataset
+    assert len(converted_dataset.document_converters) == 1
+    assert TestDocument in converted_dataset.document_converters
+    assert converted_dataset.document_converters[TestDocument] == convert_to_document_with_label
+
+
+def test_to_document_type_convert_and_cast(dataset_with_converter_functions):
+    @dataclass
+    class TestDocumentWithLabelAndSpans(TestDocumentWithLabel):
+        label: AnnotationList[Label] = annotation_field()
+        spans: AnnotationList[Span] = annotation_field(target="text")
+
+    assert dataset_with_converter_functions.document_type == TestDocument
+    # The only converter is registered for TestDocumentWithLabel, but we request a conversion to
+    # TestDocumentWithLabelAndSpans which is a *subclass* of TestDocumentWithLabel. This is a valid type
+    # and the conversion is performed by first converting to TestDocumentWithLabel and then casting
+    # to TestDocumentWithLabelAndSpans.
+    converted_dataset = dataset_with_converter_functions.to_document_type(
+        TestDocumentWithLabelAndSpans
+    )
+    assert converted_dataset.document_type == TestDocumentWithLabelAndSpans
+
+    assert len(converted_dataset.document_converters) == 0
+    for converted_doc, doc in zip(converted_dataset, dataset_with_converter_functions):
+        assert isinstance(doc, TestDocument)
+        assert isinstance(converted_doc, TestDocumentWithLabelAndSpans)
+        assert converted_doc.text == doc.text
+        assert len(converted_doc.label) == 1
+        assert converted_doc.label[0].label == "label"
+        assert len(converted_doc.spans) == 0
+
+
+def test_to_document_type_not_found(dataset_with_converter_functions):
+    assert dataset_with_converter_functions.document_type == TestDocument
+    # The only converter is registered for TestDocumentWithLabel, but we request a conversion to
+    # TextDocument which is a *superclass* of TestDocumentWithLabel. This is not a valid type,
+    # so just a simple cast is performed.
+    converted_dataset = dataset_with_converter_functions.to_document_type(TextDocument)
+    assert converted_dataset.document_type == TextDocument
+
+    assert len(converted_dataset.document_converters) == 0
+    for converted_doc, doc in zip(converted_dataset, dataset_with_converter_functions):
+        assert isinstance(doc, TestDocument)
+        assert isinstance(converted_doc, TextDocument)
+        assert converted_doc.text == doc.text
+        annotation_filed_names = {f.name for f in converted_doc.annotation_fields()}
+        assert annotation_filed_names == set()

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -15,6 +15,7 @@ from pytorch_ie.core.taskmodule import (
     TaskEncodingDataset,
     TaskEncodingSequence,
 )
+from pytorch_ie.data.dataset import get_pie_dataset_type
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.taskmodules import TransformerSpanClassificationTaskModule
 from tests import DATASET_BUILDERS_ROOT
@@ -299,3 +300,14 @@ def test_load_with_hf_datasets_from_hub():
     assert len(dataset["train"]) == 14041
     assert len(dataset["validation"]) == 3250
     assert len(dataset["test"]) == 3453
+
+
+def test_get_pie_dataset_type(json_dataset, iterable_json_dataset):
+    assert get_pie_dataset_type(json_dataset["train"]) == Dataset
+    assert get_pie_dataset_type(iterable_json_dataset["train"]) == IterableDataset
+    with pytest.raises(TypeError) as excinfo:
+        get_pie_dataset_type("not a dataset")
+    assert (
+        str(excinfo.value)
+        == "the dataset must be of type Dataset or IterableDataset, but is of type <class 'str'>"
+    )

--- a/tests/data/test_dataset_dict.py
+++ b/tests/data/test_dataset_dict.py
@@ -15,7 +15,7 @@ from pytorch_ie.data.common import (
     ExitDatasetDictMixin,
     ExitDatasetMixin,
 )
-from pytorch_ie.data.dataset_dict import get_pie_dataset_type
+from pytorch_ie.data.dataset import get_pie_dataset_type
 from pytorch_ie.documents import TextBasedDocument
 from tests import FIXTURES_ROOT
 

--- a/tests/data/test_dataset_dict.py
+++ b/tests/data/test_dataset_dict.py
@@ -151,8 +151,12 @@ def test_get_pie_dataset_type():
         "json", data_dir=DATA_PATH, split="train", streaming=True
     )
     assert get_pie_dataset_type(hf_ds_iterable) == IterableDataset
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError) as excinfo:
         get_pie_dataset_type("not a dataset")
+    assert (
+        str(excinfo.value)
+        == "the dataset must be of type Dataset or IterableDataset, but is of type <class 'str'>"
+    )
 
 
 def map_fn(doc):

--- a/tests/data/test_dataset_dict.py
+++ b/tests/data/test_dataset_dict.py
@@ -15,7 +15,6 @@ from pytorch_ie.data.common import (
     ExitDatasetDictMixin,
     ExitDatasetMixin,
 )
-from pytorch_ie.data.dataset import get_pie_dataset_type
 from pytorch_ie.documents import TextBasedDocument
 from tests import FIXTURES_ROOT
 
@@ -142,21 +141,6 @@ def test_dataset_type_different_type(dataset_dict, iterable_dataset_dict):
     with pytest.raises(ValueError) as excinfo:
         dataset_dict_different_type.dataset_type
     assert str(excinfo.value).startswith("dataset contains splits with different dataset types:")
-
-
-def test_get_pie_dataset_type():
-    hf_ds = datasets.load_dataset("json", data_dir=DATA_PATH, split="train")
-    assert get_pie_dataset_type(hf_ds) == Dataset
-    hf_ds_iterable = datasets.load_dataset(
-        "json", data_dir=DATA_PATH, split="train", streaming=True
-    )
-    assert get_pie_dataset_type(hf_ds_iterable) == IterableDataset
-    with pytest.raises(TypeError) as excinfo:
-        get_pie_dataset_type("not a dataset")
-    assert (
-        str(excinfo.value)
-        == "the dataset must be of type Dataset or IterableDataset, but is of type <class 'str'>"
-    )
 
 
 def map_fn(doc):

--- a/tests/data/test_dataset_dict.py
+++ b/tests/data/test_dataset_dict.py
@@ -482,3 +482,38 @@ def test_register_document_converter_resolve_wrong_converter(dataset_dict):
     with pytest.raises(TypeError) as excinfo:
         dataset_dict.register_document_converter([1, 2, 3], document_type=TestDocumentWithLabel)
     assert str(excinfo.value) == "converter must be a callable or a dict, but is <class 'list'>"
+
+
+def test_to_document_type(dataset_dict):
+    dataset_dict.register_document_converter(convert_to_document_with_label)
+    dataset_dict_converted = dataset_dict.to_document_type(TestDocumentWithLabel)
+    assert dataset_dict_converted.document_type == TestDocumentWithLabel
+    for split in dataset_dict_converted.values():
+        assert all(isinstance(doc, TestDocumentWithLabel) for doc in split)
+
+
+def test_to_document_resolve(dataset_dict):
+    dataset_dict.register_document_converter(convert_to_document_with_label)
+    dataset_dict_converted = dataset_dict.to_document_type(
+        "tests.data.test_dataset_dict.TestDocumentWithLabel"
+    )
+    assert dataset_dict_converted.document_type == TestDocumentWithLabel
+    for split in dataset_dict_converted.values():
+        assert all(isinstance(doc, TestDocumentWithLabel) for doc in split)
+
+
+def test_to_document_type_resolve_wrong_document_type(dataset_dict):
+    dataset_dict.register_document_converter(convert_to_document_with_label)
+    with pytest.raises(TypeError) as excinfo:
+        dataset_dict.to_document_type("tests.data.test_dataset_dict.NoDocument")
+    assert (
+        str(excinfo.value)
+        == "document_type must be a document type or a string that can be resolved to such a type, but got tests.data.test_dataset_dict.NoDocument."
+    )
+
+
+def test_to_document_type_noop(dataset_dict):
+    assert dataset_dict.document_type == DocumentWithEntitiesAndRelations
+    dataset_dict_converted = dataset_dict.to_document_type(DocumentWithEntitiesAndRelations)
+    assert dataset_dict_converted.document_type == DocumentWithEntitiesAndRelations
+    assert dataset_dict_converted == dataset_dict


### PR DESCRIPTION
This PR moves the main logic for document preparation, i.e. converting the documents of a loaded dataset to a format that is understood by a taskmodule, to the dataset builder scripts. As a result, that
1) logic is easily sharable via the Huggingface hub, and 
2) allows for document auto-conversion.

With this PR, document converters can be added to dataset builders either as class variable `DOCUMENT_CONVERTS` or dynamically via the parameter `document_converts` when calling `load_dataset()` . In addition, `Dataset`, `IterabelDataset`, and `DatasetDict` have to new methods:
 - `register_document_converter(converter, document_type=None)`: register a new convert function for a target document type. If the document type is not provided, it is tried to infer it from the converter return type
 - `to_document_type(document_type)`: convert to the document type by using the registered converters.

If the converter is a function, it will via `map()` to all documents. If it is a dict, it is interpreted as a field name mapping and we perform a simple cast with it. If no converter is registered for the requested document type, but for a super class of it, we use that one and cast to the requested document type afterwards.

In addition, `TaskModule`s can now define a class parameter `DOCUMENT_TYPE` (default is `None`) to signal what document type they require. This value can and should be accessed via `taskmodule.document_type`. Per default, this just returns the value of `DOCUMENT_TYPE`, but can be used to implement special variants, e.g. if we want to use sentence partitions, the taskmodule should return `TextDocumentWith...AndSentences` instead of just `TextDocumentWith...`.

Usage in downstream projects (e.g. created from `pytorch-ie-hydra-template`):
- in train.py, evaluate.py and predict.py: call `dataset = dataset.to_document_type(taskmodule.document_type)` if that value is available and `dataset.document_type` is not already a subclass of it
- in addition, for dataset configs that require task specific preprocessing (e.g. RE) call `DatasetDict.to_document_type(...)` via `_convert_documents.yaml` before these preprocessing steps
- when using generic dataset scripts (e.g. `pie/brat`), add converters via the `document_converters` parameter for `load_dataset()`

This also adds the following document types to be used as common reference points:
 - `TextDocumentWithEntitiesAndRelations`
 - `TextDocumentWithLabeledEntitiesAndRelations`
 - `TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions`
 - and more

Todo:
- [x] register_converter (also in PieBuilder init) should work without a document_type, but try to infer it from the result type Annotation of the converter if it is a callable)
- ~convert_to() should accept a list of document_type and try them one by one (if a taskmodule works with multiple document types)~ Edit: we added `Taskmodule.document_type` that returns a single type
- [x] `PieDatasetBuilder` should accept a `document_converters` Parameter (instead of `document_type` and `converter`) that will update `DOCUMENT_CONVERTERS` before passing it to dataset creation (maybe convert string keys)
- [x] `convert_to()` should be `to_document_type()` and should not accept a converter
- ~swap arguments of `issubclass` in `get_best_dataset_converter_with_types()` because we "up-cast" to `document_type` afterwards (e.g. to add partitions later on)~ EDIT: This is already the case.
- [x] double-check naming: 
   - `convert_to()` method EDIT: renamed to `to_document_type()`
   -  `target_document_type` parameter for `PieDatasetBuilder` EDIT: removed
- [x] add tests