### PR TITLE
implement `token_based_document_to_text_based()`

### DIFF
--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -18,21 +18,31 @@ TeD = TypeVar("TeD", bound=TextBasedDocument)
 
 def text_based_document_to_token_based(
     doc: TextBasedDocument,
-    tokens: List[str],
     result_document_type: Type[ToD],
+    tokens: Optional[List[str]] = None,
     token_offset_mapping: Optional[List[Tuple[int, int]]] = None,
     char_to_token: Optional[Callable[[int], Optional[int]]] = None,
     strict_span_conversion: bool = True,
     verbose: bool = True,
 ) -> ToD:
+    if tokens is None:
+        tokens = doc.metadata.get("tokens")
+    if tokens is None:
+        raise ValueError(
+            "tokens must be provided to convert a text based document to token based, but got None"
+        )
     result = result_document_type(tokens=tuple(tokens), id=doc.id, metadata=deepcopy(doc.metadata))
 
     # save text, token_offset_mapping and char_to_token (if available) in metadata
     result.metadata["text"] = doc.text
     if token_offset_mapping is not None:
         result.metadata["token_offset_mapping"] = token_offset_mapping
+    else:
+        token_offset_mapping = doc.metadata.get("token_offset_mapping")
     if char_to_token is not None:
         result.metadata["char_to_token"] = char_to_token
+    else:
+        char_to_token = doc.metadata.get("char_to_token")
 
     # construct the char_to_token function, if not provided, from the token_offset_mapping
     if char_to_token is None:

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -36,10 +36,22 @@ def text_based_document_to_token_based(
     # save text, token_offset_mapping and char_to_token (if available) in metadata
     result.metadata["text"] = doc.text
     if token_offset_mapping is not None:
+        if (
+            "token_offset_mapping" in doc.metadata
+            and doc.metadata["token_offset_mapping"] != token_offset_mapping
+        ):
+            logger.warning(
+                "token_offset_mapping in metadata is different from the new token_offset_mapping, "
+                "overwrite the metadata"
+            )
         result.metadata["token_offset_mapping"] = token_offset_mapping
     else:
         token_offset_mapping = doc.metadata.get("token_offset_mapping")
     if char_to_token is not None:
+        if "char_to_token" in doc.metadata and doc.metadata["char_to_token"] != char_to_token:
+            logger.warning(
+                "char_to_token in metadata is different from the new char_to_token, overwrite the metadata"
+            )
         result.metadata["char_to_token"] = char_to_token
     else:
         char_to_token = doc.metadata.get("char_to_token")

--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -60,6 +60,11 @@ def text_based_document_to_token_based(
         override_annotations[text_span_layer_name] = {}
         char_span: Span
         for char_span in doc[text_span_layer_name]:
+            if not isinstance(char_span, Span):
+                raise ValueError(
+                    f"text span layer must contain only spans, but found {type(char_span)} in layer "
+                    f"{text_span_layer_name}"
+                )
             start_token_idx = char_to_token(char_span.start)
             end_token_idx_inclusive = char_to_token(char_span.end - 1)
             if start_token_idx is None or end_token_idx_inclusive is None:

--- a/tests/data/test_document_conversion.py
+++ b/tests/data/test_document_conversion.py
@@ -211,6 +211,150 @@ def test_token_based_document_to_text_based(documents, token_documents):
         assert reconstructed_doc_dict == doc_dict
 
 
+def test_token_based_document_to_text_based_with_join_tokens_with(documents):
+    for doc in documents:
+        # split the text by individual whitespace characters
+        # so that we can reconstruct the original text via " ".join(tokens)
+        tokens = []
+        token_offset_mapping = []
+        start = 0
+        for token in doc.text.split(" "):
+            tokens.append(token)
+            end = start + len(token)
+            token_offset_mapping.append((start, end))
+            start = end + 1
+
+        tokenized_doc = text_based_document_to_token_based(
+            doc,
+            tokens=tokens,
+            result_document_type=TokenizedTestDocument,
+            token_offset_mapping=token_offset_mapping,
+        )
+        reconstructed_doc = token_based_document_to_text_based(
+            tokenized_doc,
+            result_document_type=TestDocument,
+            join_tokens_with=" ",
+        )
+        assert reconstructed_doc is not None
+        assert reconstructed_doc.text == doc.text
+
+        if doc.id in ["train_doc1", "train_doc7"]:
+            doc_dict = doc.asdict()
+            reconstructed_doc_dict = reconstructed_doc.asdict()
+            # remove all added metadata (original text, token_offset_mapping, char_to_token, tokens)
+            reconstructed_doc_dict["metadata"] = {
+                k: reconstructed_doc_dict["metadata"][k] for k in doc_dict["metadata"]
+            }
+            assert reconstructed_doc_dict == doc_dict
+        elif doc.id == "train_doc2":
+            assert reconstructed_doc.sentences == doc.sentences
+            assert len(reconstructed_doc.entities) == len(doc.entities) == 2
+            assert str(reconstructed_doc.entities[0]) == str(doc.entities[0]) == "Entity A"
+            assert str(doc.entities[1]) == "B"
+            assert str(reconstructed_doc.entities[1]) == "B."
+            assert len(reconstructed_doc.relations) == len(doc.relations) == 1
+            assert (
+                reconstructed_doc.relations[0].label == doc.relations[0].label == "per:employee_of"
+            )
+            assert doc.relations[0].head == doc.entities[0]
+            assert reconstructed_doc.relations[0].head == reconstructed_doc.entities[0]
+            assert doc.relations[0].tail == doc.entities[1]
+            assert reconstructed_doc.relations[0].tail == reconstructed_doc.entities[1]
+        elif doc.id == "train_doc3":
+            assert reconstructed_doc.sentences == doc.sentences
+            assert len(reconstructed_doc.entities) == len(doc.entities) == 2
+            assert str(reconstructed_doc.entities[0]) == str(doc.entities[0]) == "Entity C"
+            assert str(doc.entities[1]) == "D"
+            assert str(reconstructed_doc.entities[1]) == "D."
+            assert len(reconstructed_doc.relations) == len(doc.relations) == 0
+        elif doc.id == "train_doc4":
+            assert reconstructed_doc.sentences == doc.sentences
+            assert len(reconstructed_doc.entities) == len(doc.entities) == 2
+            assert str(reconstructed_doc.entities[0]) == str(doc.entities[0]) == "Entity E"
+            assert str(doc.entities[1]) == "F"
+            assert str(reconstructed_doc.entities[1]) == "F."
+            assert len(reconstructed_doc.relations) == len(doc.relations) == 0
+        elif doc.id == "train_doc5":
+            assert reconstructed_doc.sentences == doc.sentences
+            assert len(reconstructed_doc.entities) == len(doc.entities) == 3
+            assert str(reconstructed_doc.entities[0]) == str(doc.entities[0]) == "Entity G"
+            assert str(doc.entities[1]) == "H"
+            assert str(reconstructed_doc.entities[1]) == "H."
+            assert str(doc.entities[2]) == "I"
+            assert str(reconstructed_doc.entities[2]) == "I."
+            assert len(reconstructed_doc.relations) == len(doc.relations) == 3
+            assert (
+                reconstructed_doc.relations[0].label == doc.relations[0].label == "per:employee_of"
+            )
+            assert doc.relations[0].head == doc.entities[0]
+            assert reconstructed_doc.relations[0].head == reconstructed_doc.entities[0]
+            assert doc.relations[0].tail == doc.entities[1]
+            assert reconstructed_doc.relations[0].tail == reconstructed_doc.entities[1]
+            assert reconstructed_doc.relations[1].label == doc.relations[1].label == "per:founder"
+            assert doc.relations[1].head == doc.entities[0]
+            assert reconstructed_doc.relations[1].head == reconstructed_doc.entities[0]
+            assert doc.relations[1].tail == doc.entities[2]
+            assert reconstructed_doc.relations[1].tail == reconstructed_doc.entities[2]
+            assert (
+                reconstructed_doc.relations[2].label == doc.relations[2].label == "org:founded_by"
+            )
+            assert doc.relations[2].head == doc.entities[2]
+            assert reconstructed_doc.relations[2].head == reconstructed_doc.entities[2]
+            assert doc.relations[2].tail == doc.entities[1]
+            assert reconstructed_doc.relations[2].tail == reconstructed_doc.entities[1]
+        elif doc.id == "train_doc6":
+            assert reconstructed_doc.sentences == doc.sentences
+            assert len(reconstructed_doc.entities) == len(doc.entities) == 3
+            assert str(doc.entities[0]) == "Entity J"
+            assert str(reconstructed_doc.entities[0]) == "Entity J,"
+            assert str(doc.entities[1]) == "K"
+            assert str(reconstructed_doc.entities[1]) == "K,"
+            assert str(doc.entities[2]) == "L"
+            assert str(reconstructed_doc.entities[2]) == "L."
+            assert len(reconstructed_doc.relations) == len(doc.relations) == 0
+        elif doc.id == "train_doc8":
+            assert len(reconstructed_doc.sentences) == len(doc.sentences) == 3
+            assert (
+                str(reconstructed_doc.sentences[0]) == str(doc.sentences[0]) == "First sentence."
+            )
+            assert (
+                str(reconstructed_doc.sentences[1])
+                == str(doc.sentences[1])
+                == "Entity M works at N."
+            )
+            assert str(doc.sentences[2]) == "And it founded O"
+            assert str(reconstructed_doc.sentences[2]) == "And it founded O."
+            assert len(reconstructed_doc.entities) == len(doc.entities) == 4
+            assert str(reconstructed_doc.entities[0]) == str(doc.entities[0]) == "Entity M"
+            assert str(doc.entities[1]) == "N"
+            assert str(reconstructed_doc.entities[1]) == "N."
+            assert str(reconstructed_doc.entities[2]) == str(doc.entities[2]) == "it"
+            assert str(doc.entities[3]) == "O"
+            assert str(reconstructed_doc.entities[3]) == "O."
+            assert len(reconstructed_doc.relations) == len(doc.relations) == 3
+            assert (
+                reconstructed_doc.relations[0].label == doc.relations[0].label == "per:employee_of"
+            )
+            assert doc.relations[0].head == doc.entities[0]
+            assert reconstructed_doc.relations[0].head == reconstructed_doc.entities[0]
+            assert doc.relations[0].tail == doc.entities[1]
+            assert reconstructed_doc.relations[0].tail == reconstructed_doc.entities[1]
+            assert reconstructed_doc.relations[1].label == doc.relations[1].label == "per:founder"
+            assert doc.relations[1].head == doc.entities[2]
+            assert reconstructed_doc.relations[1].head == reconstructed_doc.entities[2]
+            assert doc.relations[1].tail == doc.entities[3]
+            assert reconstructed_doc.relations[1].tail == reconstructed_doc.entities[3]
+            assert (
+                reconstructed_doc.relations[2].label == doc.relations[2].label == "org:founded_by"
+            )
+            assert doc.relations[2].head == doc.entities[3]
+            assert reconstructed_doc.relations[2].head == reconstructed_doc.entities[3]
+            assert doc.relations[2].tail == doc.entities[2]
+            assert reconstructed_doc.relations[2].tail == reconstructed_doc.entities[2]
+        else:
+            raise ValueError(f"Unexpected document: {doc.id}")
+
+
 def test_tokenize_document(documents, tokenizer):
     doc = documents[1]
     tokenized_docs = tokenize_document(

--- a/tests/data/test_document_conversion.py
+++ b/tests/data/test_document_conversion.py
@@ -200,8 +200,6 @@ def test_token_based_document_to_text_based(documents, token_documents):
         reconstructed_doc = token_based_document_to_text_based(
             tokenized_doc,
             result_document_type=TestDocument,
-            text=tokenized_doc.metadata["text"],
-            token_offset_mapping=tokenized_doc.metadata["token_offset_mapping"],
         )
         assert reconstructed_doc is not None
         doc_dict = doc.asdict()


### PR DESCRIPTION
in analogy to `text_based_document_to_token_based()` (see #315).

This also adds the following improvements to `text_based_document_to_token_based()`:
 - use `tokens`, `token_offset_mapping`, and `char_to_token` from metadata, if available there and not explicitly provided,  and warn, if provided, but different to entries in metadata
 - raise an exception if the layers that target the text (the layers we want to modify) consist of annotations that are no `Span`s