### PR TITLE
fix and improve `token_based_document_to_text_based()`

### DIFF
--- a/src/pytorch_ie/data/__init__.py
+++ b/src/pytorch_ie/data/__init__.py
@@ -2,7 +2,11 @@ from .builder import GeneratorBasedBuilder
 from .dataset import Dataset, IterableDataset
 from .dataset_dict import DatasetDict
 from .dataset_formatter import DocumentFormatter
-from .document_conversion import text_based_document_to_token_based, tokenize_document
+from .document_conversion import (
+    text_based_document_to_token_based,
+    token_based_document_to_text_based,
+    tokenize_document,
+)
 
 __all__ = [
     "GeneratorBasedBuilder",
@@ -11,5 +15,6 @@ __all__ = [
     "DatasetDict",
     "DocumentFormatter",
     "text_based_document_to_token_based",
+    "token_based_document_to_text_based",
     "tokenize_document",
 ]

--- a/tests/data/test_document_conversion.py
+++ b/tests/data/test_document_conversion.py
@@ -3,10 +3,13 @@ import dataclasses
 import pytest
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
-from pytorch_ie import text_based_document_to_token_based, tokenize_document
+from pytorch_ie import (
+    text_based_document_to_token_based,
+    token_based_document_to_text_based,
+    tokenize_document,
+)
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
 from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.data.document_conversion import token_based_document_to_text_based
 from pytorch_ie.documents import TokenBasedDocument
 from tests.conftest import TestDocument
 


### PR DESCRIPTION
this was left out from #334:
- fix the export
- allow string values for `result_document_type` (also for `text_based_document_to_token_based()`)
- improve error message