### PR TITLE
`document_type` for `DocumentMetric`s

### DIFF
--- a/src/pytorch_ie/core/__init__.py
+++ b/src/pytorch_ie/core/__init__.py
@@ -1,5 +1,6 @@
 from .document import Annotation, AnnotationList, Document, annotation_field
 from .metric import DocumentMetric
 from .model import PyTorchIEModel
+from .module_mixins import RequiresDocumentTypeMixin
 from .statistic import DocumentStatistic
 from .taskmodule import TaskEncoding, TaskModule

--- a/src/pytorch_ie/core/metric.py
+++ b/src/pytorch_ie/core/metric.py
@@ -1,27 +1,18 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, Iterable, Optional, Type, TypeVar, Union
+from typing import Dict, Generic, Iterable, Optional, TypeVar, Union
 
 from pytorch_ie.core.document import Document
+from pytorch_ie.core.module_mixins import RequiresDocumentTypeMixin
 
 T = TypeVar("T")
 
 
-class DocumentMetric(ABC, Generic[T]):
+class DocumentMetric(ABC, RequiresDocumentTypeMixin, Generic[T]):
     """This defines the interface for a document metric."""
-
-    # The document type that this metric can process. Will be used for auto-conversion, if available.
-    # Overwrite this if the metric requires a specific document type, e.g. a TextBasedDocument.
-    DOCUMENT_TYPE: Optional[Type[Document]] = None
 
     def __init__(self):
         self.reset()
         self._current_split: Optional[str] = None
-
-    @property
-    def document_type(self) -> Optional[Type[Document]]:
-        """The document type that this metric can process. Will be used for auto-conversion, if available.
-        Overwrite this if the document type depends on some parameters of the metric."""
-        return self.DOCUMENT_TYPE
 
     @abstractmethod
     def reset(self) -> None:

--- a/src/pytorch_ie/core/metric.py
+++ b/src/pytorch_ie/core/metric.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, Iterable, Optional, TypeVar, Union
+from typing import Dict, Generic, Iterable, Optional, Type, TypeVar, Union
 
 from pytorch_ie.core.document import Document
 
@@ -9,9 +9,19 @@ T = TypeVar("T")
 class DocumentMetric(ABC, Generic[T]):
     """This defines the interface for a document metric."""
 
+    # The document type that this metric can process. Will be used for auto-conversion, if available.
+    # Overwrite this if the metric requires a specific document type, e.g. a TextBasedDocument.
+    DOCUMENT_TYPE: Optional[Type[Document]] = None
+
     def __init__(self):
         self.reset()
         self._current_split: Optional[str] = None
+
+    @property
+    def document_type(self) -> Optional[Type[Document]]:
+        """The document type that this metric can process. Will be used for auto-conversion, if available.
+        Overwrite this if the document type depends on some parameters of the metric."""
+        return self.DOCUMENT_TYPE
 
     @abstractmethod
     def reset(self) -> None:

--- a/src/pytorch_ie/core/module_mixins.py
+++ b/src/pytorch_ie/core/module_mixins.py
@@ -1,0 +1,39 @@
+import logging
+from typing import Optional, Type
+
+from pytorch_ie.core.document import Document
+from pytorch_ie.data.dataset_dict import DatasetDict
+
+logger = logging.getLogger(__name__)
+
+
+class RequiresDocumentTypeMixin:
+
+    DOCUMENT_TYPE: Optional[Type[Document]] = None
+
+    @property
+    def document_type(self) -> Optional[Type[Document]]:
+        return self.DOCUMENT_TYPE
+
+    def convert_dataset(self, dataset: DatasetDict) -> DatasetDict:
+        name = type(self).__name__
+        # auto-convert the dataset if a document type is specified
+        if self.document_type is not None:
+            if issubclass(dataset.document_type, self.document_type):
+                logger.info(
+                    f"the dataset is already of the document type that is specified by {name}: "
+                    f"{self.document_type}"
+                )
+            else:
+                logger.info(
+                    f"convert the dataset to the document type that is specified by {name}: "
+                    f"{self.document_type}"
+                )
+                dataset = dataset.to_document_type(self.document_type)
+        else:
+            logger.warning(
+                f"{name} does not specify a document type. The dataset can not be automatically converted "
+                f"to a document type."
+            )
+
+        return dataset

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 from pytorch_ie.core.document import Document
 from pytorch_ie.core.metric import DocumentMetric
-from pytorch_ie.utils.hydra import InstantiationException, resolve_target
+from pytorch_ie.utils.hydra import InstantiationException, resolve_document_type, resolve_target
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +152,7 @@ class DocumentStatistic(DocumentMetric):
         show_as_markdown: bool = False,
         aggregation_functions: Optional[List[str]] = None,
         title: Optional[str] = None,
-        document_type: Optional[Type[Document]] = None,
+        document_type: Optional[Union[Type[Document], str]] = None,
     ) -> None:
         super().__init__()
         self.aggregation_functions = {
@@ -162,7 +162,7 @@ class DocumentStatistic(DocumentMetric):
         self.show_histogram = show_histogram
         self.show_as_markdown = show_as_markdown
         self.title = title or self.__class__.__name__
-        self._document_type = document_type
+        self._document_type = resolve_document_type(document_type)
 
     @property
     def document_type(self) -> Optional[Type[Document]]:

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -5,7 +5,11 @@ from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 from pytorch_ie.core.document import Document
 from pytorch_ie.core.metric import DocumentMetric
-from pytorch_ie.utils.hydra import InstantiationException, resolve_document_type, resolve_target
+from pytorch_ie.utils.hydra import (
+    InstantiationException,
+    resolve_optional_document_type,
+    resolve_target,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +166,7 @@ class DocumentStatistic(DocumentMetric):
         self.show_histogram = show_histogram
         self.show_as_markdown = show_as_markdown
         self.title = title or self.__class__.__name__
-        self._document_type = resolve_document_type(document_type)
+        self._document_type = resolve_optional_document_type(document_type)
 
     @property
     def document_type(self) -> Optional[Type[Document]]:

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -166,7 +166,7 @@ class DocumentStatistic(DocumentMetric):
 
     @property
     def document_type(self) -> Optional[Type[Document]]:
-        return self._document_type or self.DOCUMENT_TYPE
+        return self._document_type or super().document_type
 
     def reset(self) -> None:
         self._values: List[Any] = []

--- a/src/pytorch_ie/core/statistic.py
+++ b/src/pytorch_ie/core/statistic.py
@@ -1,7 +1,7 @@
 import logging
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 from pytorch_ie.core.document import Document
 from pytorch_ie.core.metric import DocumentMetric
@@ -152,6 +152,7 @@ class DocumentStatistic(DocumentMetric):
         show_as_markdown: bool = False,
         aggregation_functions: Optional[List[str]] = None,
         title: Optional[str] = None,
+        document_type: Optional[Type[Document]] = None,
     ) -> None:
         super().__init__()
         self.aggregation_functions = {
@@ -161,6 +162,11 @@ class DocumentStatistic(DocumentMetric):
         self.show_histogram = show_histogram
         self.show_as_markdown = show_as_markdown
         self.title = title or self.__class__.__name__
+        self._document_type = document_type
+
+    @property
+    def document_type(self) -> Optional[Type[Document]]:
+        return self._document_type or self.DOCUMENT_TYPE
 
     def reset(self) -> None:
         self._values: List[Any] = []

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -12,7 +12,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Type,
     TypeVar,
     Union,
     overload,
@@ -24,6 +23,7 @@ from tqdm import tqdm
 
 from pytorch_ie.core.document import Annotation, Document
 from pytorch_ie.core.hf_hub_mixin import PieTaskModuleHFHubMixin
+from pytorch_ie.core.module_mixins import RequiresDocumentTypeMixin
 from pytorch_ie.core.registrable import Registrable
 from pytorch_ie.data import Dataset, IterableDataset
 
@@ -149,6 +149,7 @@ class TaskModule(
     PieTaskModuleHFHubMixin,
     HyperparametersMixin,
     Registrable,
+    RequiresDocumentTypeMixin,
     Generic[
         DocumentType,
         InputEncoding,
@@ -159,15 +160,10 @@ class TaskModule(
     ],
 ):
     PREPARED_ATTRIBUTES: List[str] = []
-    DOCUMENT_TYPE: Optional[Type[DocumentType]] = None
 
     def __init__(self, encode_document_batch_size: Optional[int] = None, **kwargs):
         super().__init__(**kwargs)
         self.encode_document_batch_size = encode_document_batch_size
-
-    @property
-    def document_type(self) -> Optional[Type[DocumentType]]:
-        return self.DOCUMENT_TYPE
 
     @property
     def is_prepared(self):

--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -159,6 +159,12 @@ def _get_best_dataset_converter_with_types(
     # first try to find an exact match
     if document_type in dataset.document_converters:
         return dataset.document_converters[document_type], document_type, document_type
+
+    # then try to find a match with a superclass
+    for registered_dt, candidate_converter in dataset.document_converters.items():
+        if issubclass(registered_dt, document_type):
+            return candidate_converter, document_type, registered_dt
+
     # then try to find a match with a subclass
     for registered_dt, candidate_converter in dataset.document_converters.items():
         if issubclass(document_type, registered_dt):
@@ -218,8 +224,8 @@ def dataset_to_document_type(
         result = result.cast_document_type(
             new_document_type=registered_type, field_mapping=converter, **kwargs
         )
-    # if the requested type is different from the registered type, try to cast (again)
-    if requested_type != registered_type:
+    # if the type is not the same or a subclass of the requested type, try to cast (again)
+    if not issubclass(registered_type, requested_type):
         result = result.cast_document_type(new_document_type=requested_type)
 
     # remove the document converters because they are not valid anymore

--- a/src/pytorch_ie/metrics/statistics.py
+++ b/src/pytorch_ie/metrics/statistics.py
@@ -1,25 +1,29 @@
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from pytorch_ie.core import Document, DocumentStatistic
+from pytorch_ie.documents import TextBasedDocument
 
 
 class TokenCountCollector(DocumentStatistic):
     """Collects the token count of a field when tokenizing its content with a Huggingface tokenizer.
 
-    The field should be a string.
+    The content of the field should be a string.
     """
 
     def __init__(
         self,
         tokenizer: Union[str, PreTrainedTokenizer],
-        text_field: str,
+        text_field: str = "text",
         tokenizer_kwargs: Optional[Dict[str, Any]] = None,
+        document_type: Optional[Type[Document]] = None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        if document_type is None and text_field == "text":
+            document_type = TextBasedDocument
+        super().__init__(document_type=document_type, **kwargs)
         self.tokenizer = (
             AutoTokenizer.from_pretrained(tokenizer) if isinstance(tokenizer, str) else tokenizer
         )


### PR DESCRIPTION
Similar to `TaskModules`, `DocumentMetric`s require documents of a certain type as input. This PR adds the functionality to let `DocumentMetrics`s signal what document type they need.

In detail:
- create `RequiresDocumentTypeMixin` that defines the class variable `DOCUMENT_TYPE` and the property `document_type` (which returns `DOCUMENT_TYPE` per default). It also defines the method `convert_dataset()` that checks for several edge cases before calling `dataset.to_document_type(self.document_type)` 
- use `RequiresDocumentTypeMixin` for `DocumentMetric` and also for `TaskModule`
- add the parameter `document_type` to  `DocumentStatistic`s that will be returned when calling `DocumentStatistic.document_type` (it overwrites `DOCUMENT_TYPE`)
- adjust the logic of `(Iterable)Dataset(Dict).to_document_type()`: we now also allow converters that are registered for document types that are *subclasses* of the requested type (e.g. if we have a converter for `DocWithEntitiesAndRelations`, but just need `DocWithEntities`, we still use that converter)