### PR TITLE
(de-)serialize `document_type` when calling `DatasetDict`

### DIFF
--- a/src/pytorch_ie/utils/hydra.py
+++ b/src/pytorch_ie/utils/hydra.py
@@ -104,3 +104,7 @@ def resolve_optional_document_type(
             f"(resolved) document_type must be a subclass of Document, but it is: {dt}"
         )
     return dt
+
+
+def serialize_document_type(document_type: Type[Document]) -> str:
+    return f"{document_type.__module__}.{document_type.__name__}"

--- a/tests/data/test_dataset_dict.py
+++ b/tests/data/test_dataset_dict.py
@@ -52,6 +52,15 @@ def test_from_json(dataset_dict):
     assert len(dataset_dict["validation"]) == 3
 
 
+def test_from_json_no_serialized_document_type(dataset_dict):
+    with pytest.raises(ValueError) as excinfo:
+        DatasetDict.from_json(data_dir=DATA_PATH)
+    assert (
+        str(excinfo.value)
+        == "document_type must be provided if it cannot be loaded from the metadata file"
+    )
+
+
 def test_load_dataset():
     dataset_dict = DatasetDict.load_dataset(
         "pie/brat", base_dataset_kwargs=dict(data_dir=FIXTURES_ROOT / "datasets" / "brat")
@@ -82,6 +91,19 @@ def test_to_json_and_back(dataset_dict, tmp_path):
     dataset_dict_from_json = DatasetDict.from_json(
         data_dir=path,
         document_type=dataset_dict.document_type,
+    )
+    assert set(dataset_dict_from_json) == set(dataset_dict)
+    for split in dataset_dict:
+        assert len(dataset_dict_from_json[split]) == len(dataset_dict[split])
+        for doc1, doc2 in zip(dataset_dict_from_json[split], dataset_dict[split]):
+            assert doc1 == doc2
+
+
+def test_to_json_and_back_serialize_document_type(dataset_dict, tmp_path):
+    path = Path(tmp_path) / "dataset_dict"
+    dataset_dict.to_json(path)
+    dataset_dict_from_json = DatasetDict.from_json(
+        data_dir=path,
     )
     assert set(dataset_dict_from_json) == set(dataset_dict)
     for split in dataset_dict:

--- a/tests/utils/test_hydra.py
+++ b/tests/utils/test_hydra.py
@@ -8,7 +8,9 @@ from pytorch_ie.utils.hydra import (
     InstantiationException,
     resolve_optional_document_type,
     resolve_target,
+    serialize_document_type,
 )
+from tests.conftest import TestDocument
 
 
 def test_resolve_target_string():
@@ -102,3 +104,10 @@ def test_resolve_optional_document_type_no_document():
         str(excinfo.value)
         == "(resolved) document_type must be a subclass of Document, but it is: <class 'tests.utils.test_hydra.NoDocument'>"
     )
+
+
+def test_serialize_document_type():
+    serialized_dt = serialize_document_type(TestDocument)
+    assert serialized_dt == "tests.conftest.TestDocument"
+    resolved_dt = resolve_optional_document_type(serialized_dt)
+    assert resolved_dt == TestDocument


### PR DESCRIPTION
With this PR, we serialize the `document_type` when calling `DatasetDict.to_json()`. The `document_type` is saved in a file `metadata.json` in the output path. And it is tried to load it from there when calling `DatasetDict.from_json()` if no `document_type` is specified (which is now optional for this method). 