### PR TITLE
Fix document types with partitions

### DIFF
--- a/src/pytorch_ie/documents.py
+++ b/src/pytorch_ie/documents.py
@@ -111,7 +111,16 @@ class TextDocumentWithEntitiesAndRelations(TextDocumentWithEntities):
 
 
 @dataclasses.dataclass
+class TextDocumentWithEntitiesAndLabeledPartitions(
+    TextDocumentWithEntities, TextDocumentWithLabeledPartitions
+):
+    pass
+
+
+@dataclasses.dataclass
 class TextDocumentWithEntitiesRelationsAndLabeledPartitions(
-    TextDocumentWithEntitiesAndRelations, TextDocumentWithLabeledPartitions
+    TextDocumentWithEntitiesAndLabeledPartitions,
+    TextDocumentWithEntitiesAndRelations,
+    TextDocumentWithLabeledPartitions,
 ):
     pass

--- a/src/pytorch_ie/documents.py
+++ b/src/pytorch_ie/documents.py
@@ -98,7 +98,9 @@ class TextDocumentWithLabeledEntitiesAndRelations(TextDocumentWithLabeledEntitie
 
 @dataclasses.dataclass
 class TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions(
-    TextDocumentWithLabeledEntitiesAndRelations, TextDocumentWithLabeledPartitions
+    TextDocumentWithLabeledEntitiesAndLabeledPartitions,
+    TextDocumentWithLabeledEntitiesAndRelations,
+    TextDocumentWithLabeledPartitions,
 ):
     pass
 


### PR DESCRIPTION
`TextDocumentWith(Labeled)EntitiesRelationsAndLabeledPartitions` need  to be derived from `TextDocumentWith(Labeled)EntitiesAndLabeledPartitions`, otherwise auto-conversion would fail if we request the latter, but have a converter to the former.