### PR TITLE
infer labels in `LabelCountCollector`

### DIFF
--- a/src/pytorch_ie/metrics/statistics.py
+++ b/src/pytorch_ie/metrics/statistics.py
@@ -132,7 +132,9 @@ class LabelCountCollector(DocumentStatistic):
                 f"functions that rely on zero values."
             )
             self.aggregation_functions = {
-                name: func for name, func in self.aggregation_functions.items() if name not in ["mean", "std", "min"]
+                name: func
+                for name, func in self.aggregation_functions.items()
+                if name not in ["mean", "std", "min"]
             }
 
         self.labels = labels

--- a/src/pytorch_ie/metrics/statistics.py
+++ b/src/pytorch_ie/metrics/statistics.py
@@ -131,9 +131,9 @@ class LabelCountCollector(DocumentStatistic):
                 f"this collector, but be aware that the results may be wrong for your own aggregation "
                 f"functions that rely on zero values."
             )
-            self.aggregation_functions = [
-                func for func in self.aggregation_functions if func not in ["mean", "std", "min"]
-            ]
+            self.aggregation_functions = {
+                name: func for name, func in self.aggregation_functions.items() if name not in ["mean", "std", "min"]
+            }
 
         self.labels = labels
 


### PR DESCRIPTION
With this PR, we allow `labels = "INFERRED"` in which case the labels are inferred from the data. This also adds the parameter `label_attribute`.

**IMPORTANT NOTE: Inferring labels produces wrong results for certain `aggregation_functions` such as `min`, `mean`, and `std` because documents with zero entries of a certain label are not considered anymore for that label. We remove these from `aggregation_functions` if `labels == "INFERRED"`, but we can not handle any user defined function (which relies on correct zero values).**