### PR TITLE
save entries of `token_offset_mapping` as lists in document metadata

### DIFF
--- a/src/pytorch_ie/data/document_conversion.py
+++ b/src/pytorch_ie/data/document_conversion.py
@@ -63,7 +63,7 @@ def text_based_document_to_token_based(
     else:
         token_offset_mapping_lists = doc.metadata.get("token_offset_mapping")
         if token_offset_mapping_lists is not None:
-            token_offset_mapping = [tuple(offsets) for offsets in token_offset_mapping_lists] # type: ignore
+            token_offset_mapping = [tuple(offsets) for offsets in token_offset_mapping_lists]  # type: ignore
     if char_to_token is not None:
         if "char_to_token" in doc.metadata and doc.metadata["char_to_token"] != char_to_token:
             logger.warning(
@@ -183,7 +183,7 @@ def token_based_document_to_text_based(
                 "if join_tokens_with is None, token_offsets must be provided, but got None as well"
             )
         else:
-            token_offset_mapping = [tuple(offsets) for offsets in token_offset_mapping_lists] # type: ignore
+            token_offset_mapping = [tuple(offsets) for offsets in token_offset_mapping_lists]  # type: ignore
 
     result = document_type(text=text, id=doc.id, metadata=deepcopy(doc.metadata))
     if "tokens" in doc.metadata and doc.metadata["tokens"] != list(doc.tokens):

--- a/tests/data/test_document_conversion.py
+++ b/tests/data/test_document_conversion.py
@@ -44,10 +44,11 @@ def test_text_based_document_to_token_based(documents, tokenizer):
         # check (de-)serialization
         tokenized_doc.copy()
 
+        offset_mapping_lists = [list(offsets) for offsets in tokenized_text.offset_mapping]
         if i == 0:
             assert doc.id == "train_doc1"
             assert tokenized_doc.metadata["text"] == doc.text == "A single sentence."
-            assert tokenized_doc.metadata["token_offset_mapping"] == tokenized_text.offset_mapping
+            assert tokenized_doc.metadata["token_offset_mapping"] == offset_mapping_lists
             assert tokenized_doc.metadata.get("char_to_token") is None
             assert tokenized_doc.tokens == ("[CLS]", "A", "single", "sentence", ".", "[SEP]")
             assert len(tokenized_doc.sentences) == len(doc.sentences) == 1
@@ -91,7 +92,7 @@ def test_text_based_document_to_token_based(documents, tokenizer):
         elif i == 2:
             assert doc.id == "train_doc3"
             assert tokenized_doc.metadata["text"] == doc.text == "Entity C and D."
-            assert tokenized_doc.metadata["token_offset_mapping"] == tokenized_text.offset_mapping
+            assert tokenized_doc.metadata["token_offset_mapping"] == offset_mapping_lists
             assert tokenized_doc.metadata["char_to_token"] == tokenized_text.char_to_token
             assert tokenized_doc.tokens == (
                 "[CLS]",


### PR DESCRIPTION
... to fix deserialization. Serializing and deserializing `token_offset_mapping` produces lists of lists in any way (json does not know tuples), so we save the entries (start and end offset) as lists in the first place. Otherwise, this breaks equality checks with deserialized documents.