### PR TITLE
auto-conversion requires a matching entry in `document_converts`

### DIFF
--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -155,7 +155,7 @@ DocumentConvertersType = Dict[Type[D], Union[Callable[..., D], Dict[str, str]]]
 def _get_best_dataset_converter_with_types(
     dataset: Union["IterableDataset", "Dataset"],
     document_type: Union[Type[Document]],
-) -> Tuple[Union[Callable[..., Document], Dict[str, str], None], Type[Document], Type[Document]]:
+) -> Tuple[Union[Callable[..., Document], Dict[str, str]], Type[Document], Type[Document]]:
     # first try to find an exact match
     if document_type in dataset.document_converters:
         return dataset.document_converters[document_type], document_type, document_type
@@ -170,13 +170,13 @@ def _get_best_dataset_converter_with_types(
         if issubclass(document_type, registered_dt):
             return candidate_converter, document_type, registered_dt
 
-    # return no converter, the requested type and the registered type
-    logger.warning(
-        f"document_type {document_type} is not in document_converters: "
-        f"{[dt.__name__ for dt in dataset.document_converters]}. "
-        "Perform a simple cast instead of a conversion."
+    raise ValueError(
+        f"No valid key (either subclass or superclass) was found for the document type '{document_type}' "
+        f"in the document_converters of the dataset. Available keys: {set(dataset.document_converters)}. "
+        f"Consider adding a respective converter to the dataset with "
+        f"dataset.register_document_converter(my_converter_method) where my_converter_method should accept "
+        f"{dataset.document_type} as input and return '{document_type}'."
     )
-    return None, document_type, document_type
 
 
 @overload

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -448,19 +448,16 @@ def test_to_document_type_not_found(dataset_with_converter_functions):
 
     # The only converter is registered for TestDocumentWithLabel, but we request a conversion to
     # TestDocumentWithSpans. This is not a valid type because it is neither a subclass nor a superclass of
-    # TestDocumentWithLabel, so just a simple cast is performed.
-    converted_dataset = dataset_with_converter_functions.to_document_type(TestDocumentWithSpans)
-    assert converted_dataset.document_type == TestDocumentWithSpans
-
-    assert len(converted_dataset.document_converters) == 0
-    for converted_doc, doc in zip(converted_dataset, dataset_with_converter_functions):
-        assert isinstance(doc, TestDocument)
-        assert isinstance(converted_doc, TestDocumentWithSpans)
-        assert converted_doc.text == doc.text
-        annotation_field_names = {f.name for f in doc.annotation_fields()}
-        assert annotation_field_names == {"sentences", "entities", "relations"}
-        converted_annotation_filed_names = {f.name for f in converted_doc.annotation_fields()}
-        assert converted_annotation_filed_names == {"sentences", "spans", "entities", "relations"}
-        common_annotation_field_names = annotation_field_names & converted_annotation_filed_names
-        for afn in common_annotation_field_names:
-            assert converted_doc[afn] == doc[afn]
+    # TestDocumentWithLabel, so an error is raised.
+    with pytest.raises(ValueError) as excinfo:
+        dataset_with_converter_functions.to_document_type(TestDocumentWithSpans)
+    assert (
+        str(excinfo.value)
+        == "No valid key (either subclass or superclass) was found for the document type "
+        "'<class 'tests.data.test_dataset.test_to_document_type_not_found.<locals>.TestDocumentWithSpans'>' "
+        "in the document_converters of the dataset. Available keys: "
+        "{<class 'tests.data.test_dataset.TestDocumentWithLabel'>}. Consider adding a respective converter "
+        "to the dataset with dataset.register_document_converter(my_converter_method) where "
+        "my_converter_method should accept <class 'tests.conftest.TestDocument'> as input and return "
+        "'<class 'tests.data.test_dataset.test_to_document_type_not_found.<locals>.TestDocumentWithSpans'>'."
+    )


### PR DESCRIPTION
i.e. no silent auto-cast anymore to increase transparency and to mitigate bugs