### PR TITLE
decouple `(Iterable)Dataset` from core framework (except for tests)

### DIFF
--- a/src/pytorch_ie/data/dataset.py
+++ b/src/pytorch_ie/data/dataset.py
@@ -1,19 +1,8 @@
 import logging
+from collections.abc import Iterable, Sequence
 from functools import wraps
 from inspect import Signature, isclass, signature
-from typing import (
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Callable, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union, overload
 
 import datasets
 import pandas as pd
@@ -251,10 +240,10 @@ def dataset_register_document_converter(
     dataset.document_converters[dt] = converter
 
 
-class Dataset(datasets.Dataset):
+class Dataset(datasets.Dataset, Sequence[D]):
     def __init__(
         self,
-        document_type: Type[Document],
+        document_type: Type[D],
         arrow_table: datasets.table.Table,
         info: Optional[datasets.DatasetInfo] = None,
         split: Optional[datasets.NamedSplit] = None,
@@ -288,7 +277,7 @@ class Dataset(datasets.Dataset):
     def from_hf_dataset(
         cls,
         dataset: datasets.Dataset,
-        document_type: Type[Document],
+        document_type: Type[D],
         document_converters: Optional[DocumentConvertersType] = None,
     ) -> "Dataset":
         document_dataset = cls(

--- a/src/pytorch_ie/pipeline.py
+++ b/src/pytorch_ie/pipeline.py
@@ -3,7 +3,7 @@ import os
 import warnings
 from collections import UserDict
 from contextlib import contextmanager
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, MutableSequence, Optional, Sequence, Tuple, Union
 
 import torch
 import tqdm
@@ -21,7 +21,6 @@ from pytorch_ie.core.taskmodule import (
     TaskModule,
     TaskOutput,
 )
-from pytorch_ie.data import Dataset
 
 logger = logging.getLogger(__name__)
 
@@ -204,7 +203,7 @@ class Pipeline:
 
     def preprocess(
         self,
-        documents: Union[Sequence[Document], Dataset],
+        documents: Sequence[Document],
         document_batch_size: Optional[int] = None,
         **preprocess_parameters: Dict,
     ) -> Sequence[TaskEncoding]:
@@ -294,7 +293,7 @@ class Pipeline:
 
     def __call__(
         self,
-        documents: Union[Document, Sequence[Document], Dataset],
+        documents: Union[Document, Sequence[Document]],
         *args,
         **kwargs,
     ) -> Union[Document, Sequence[Document]]:
@@ -308,9 +307,9 @@ class Pipeline:
         ) = self._sanitize_parameters(**kwargs)
 
         in_place: bool = postprocess_params.get("inplace", True)
-        if in_place and isinstance(documents, Dataset):
+        if in_place and not isinstance(documents, (MutableSequence, Document)):
             raise InplaceNotSupportedException(
-                "Datasets can't be modified in place. Please set inplace=False."
+                "Immutable sequences of Documents (such as Datasets) can't be modified in place. Please set inplace=False."
             )
 
         if "TOKENIZERS_PARALLELISM" not in os.environ:
@@ -333,7 +332,7 @@ class Pipeline:
             )
 
         single_document = False
-        if not isinstance(documents, (Sequence, Dataset)):
+        if isinstance(documents, Document):
             single_document = True
             documents = [documents]
 

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -1,6 +1,6 @@
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from typing import Dict, Sequence, Union
+from typing import Union
 
 import datasets
 import numpy

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -134,7 +134,9 @@ def test_pipeline_with_dataset(dataset, prepared_taskmodule, mock_model, inplace
     if inplace:
         with pytest.raises(
             InplaceNotSupportedException,
-            match=re.escape("Datasets can't be modified in place. Please set inplace=False."),
+            match=re.escape(
+                "Immutable sequences of Documents (such as Datasets) can't be modified in place. Please set inplace=False."
+            ),
         ):
             returned_documents = pipeline(train_dataset, inplace=inplace)
     else:


### PR DESCRIPTION
This is in preparation for outsourcing the complete logic related to PyTorch-IE  `Dataset`, `IterableDataset`, and `DatasetDict` to [pie-datasets](https://github.com/ArneBinder/pie-datasets) (see https://github.com/ArneBinder/pie-datasets/pull/21).