### PR TITLE
rename core classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,17 @@ elements:
 
 ```python
 from typing import Optional
-from pytorch_ie.core import Document, AnnotationList, annotation_field
+from pytorch_ie.core import Document, AnnotationLayer, annotation_field
 from pytorch_ie.annotations import LabeledSpan, BinaryRelation, Label
+
 
 class MyDocument(Document):
     # data fields (any field that is targeted by an annotation fields)
     text: str
     # annotation fields
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
-    label: AnnotationList[Label] = annotation_field()
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
+    label: AnnotationLayer[Label] = annotation_field()
     # other fields
     doc_id: Optional[str] = None
 ```
@@ -319,12 +320,14 @@ from dataclasses import dataclass
 
 from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.auto import AutoPipeline
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
+
 
 @dataclass
 class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+
 
 document = ExampleDocument(
     "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."
@@ -390,14 +393,15 @@ from dataclasses import dataclass
 
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan
 from pytorch_ie.auto import AutoPipeline
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
 
 
 @dataclass
 class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
+
 
 document = ExampleDocument(
     "“Making a super tasty alt-chicken wing is only half of it,” said Po Bronson, general partner at SOSV and managing director of IndieBio."

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The content of `self.target` is lazily assigned as soon as the annotation is add
 Note that this now expects a single `collections.abc.Sequence` as `target`, e.g.:
 
 ```python
-my_spans: AnnotationList[Span] = annotation_field(target="<NAME_OF_THE_SEQUENCE_FIELD>")
+my_spans: AnnotationLayer[Span] = annotation_field(target="<NAME_OF_THE_SEQUENCE_FIELD>")
 ```
 
 If we have multiple targets, we need to define target names to access them. For this, we need to set the special
@@ -179,7 +179,7 @@ class MyDocumentWithAlignment(Document):
     text_a: str
     text_b: str
     # `named_targets` defines the mapping from `TARGET_NAMES` to data fields
-    my_alignments: AnnotationList[Alignment] = annotation_field(named_targets={"text1": "text_a", "text2": "text_b"})
+    my_alignments: AnnotationLayer[Alignment] = annotation_field(named_targets={"text1": "text_a", "text2": "text_b"})
 ```
 
 Note that `text1` and `text2` can also target the same field.
@@ -554,7 +554,7 @@ print(dataset["train"][0])
 # >>> CoNLL2003Document(text='EU rejects German call to boycott British lamb .', id='0', metadata={})
 
 dataset["train"][0].entities
-# >>> AnnotationList([LabeledSpan(start=0, end=2, label='ORG', score=1.0), LabeledSpan(start=11, end=17, label='MISC', score=1.0), LabeledSpan(start=34, end=41, label='MISC', score=1.0)])
+# >>> AnnotationLayer([LabeledSpan(start=0, end=2, label='ORG', score=1.0), LabeledSpan(start=11, end=17, label='MISC', score=1.0), LabeledSpan(start=34, end=41, label='MISC', score=1.0)])
 
 entity = dataset["train"][0].entities[1]
 
@@ -575,12 +575,12 @@ dataset from that, you have to implement:
 ```python
 @dataclass
 class CoNLL2003Document(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 ```
 
 Here we derive from `TextDocument` that has a simple `text` string as base annotation target. The `CoNLL2003Document`
 adds one single annotation list called `entities` that consists of `LabeledSpan`s which reference the `text` field of
-the document. You can add further annotation types by adding `AnnotationList` fields that may also reference (i.e.
+the document. You can add further annotation types by adding `AnnotationLayer` fields that may also reference (i.e.
 `target`) other annotations as you like. See ['pytorch_ie.annotations`](src/pytorch_ie/annotations.py) for predefined
 annotation types.
 

--- a/examples/predict/ner_span_classification.py
+++ b/examples/predict/ner_span_classification.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models import TransformerSpanClassificationModel
 from pytorch_ie.pipeline import Pipeline
@@ -10,7 +10,7 @@ from pytorch_ie.taskmodules import TransformerSpanClassificationTaskModule
 
 @dataclass
 class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 
 def main():

--- a/examples/predict/re_generative.py
+++ b/examples/predict/re_generative.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models import TransformerSeq2SeqModel
 from pytorch_ie.pipeline import Pipeline
@@ -10,8 +10,8 @@ from pytorch_ie.taskmodules import TransformerSeq2SeqTaskModule
 
 @dataclass
 class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 def main():

--- a/examples/predict/re_text_classification.py
+++ b/examples/predict/re_text_classification.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models import TransformerTextClassificationModel
 from pytorch_ie.pipeline import Pipeline
@@ -10,8 +10,8 @@ from pytorch_ie.taskmodules import TransformerRETextClassificationTaskModule
 
 @dataclass
 class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 def main():

--- a/src/pytorch_ie/core/__init__.py
+++ b/src/pytorch_ie/core/__init__.py
@@ -1,6 +1,9 @@
-from .document import Annotation, AnnotationList, Document, annotation_field
+from .document import Annotation, AnnotationLayer, Document, annotation_field
 from .metric import DocumentMetric
 from .model import PyTorchIEModel
 from .module_mixins import RequiresDocumentTypeMixin
 from .statistic import DocumentStatistic
 from .taskmodule import TaskEncoding, TaskModule
+
+# backwards compatibility
+AnnotationList = AnnotationLayer

--- a/src/pytorch_ie/core/__init__.py
+++ b/src/pytorch_ie/core/__init__.py
@@ -1,9 +1,10 @@
 from .document import Annotation, AnnotationLayer, Document, annotation_field
 from .metric import DocumentMetric
 from .model import PyTorchIEModel
-from .module_mixins import RequiresDocumentTypeMixin
+from .module_mixins import WithDocumentTypeMixin
 from .statistic import DocumentStatistic
 from .taskmodule import TaskEncoding, TaskModule
 
 # backwards compatibility
 AnnotationList = AnnotationLayer
+RequiresDocumentTypeMixin = WithDocumentTypeMixin

--- a/src/pytorch_ie/core/metric.py
+++ b/src/pytorch_ie/core/metric.py
@@ -2,12 +2,12 @@ from abc import ABC, abstractmethod
 from typing import Dict, Generic, Iterable, Optional, TypeVar, Union
 
 from pytorch_ie.core.document import Document
-from pytorch_ie.core.module_mixins import RequiresDocumentTypeMixin
+from pytorch_ie.core.module_mixins import WithDocumentTypeMixin
 
 T = TypeVar("T")
 
 
-class DocumentMetric(ABC, RequiresDocumentTypeMixin, Generic[T]):
+class DocumentMetric(ABC, WithDocumentTypeMixin, Generic[T]):
     """This defines the interface for a document metric."""
 
     def __init__(self):

--- a/src/pytorch_ie/core/module_mixins.py
+++ b/src/pytorch_ie/core/module_mixins.py
@@ -6,7 +6,7 @@ from pytorch_ie.core.document import Document
 logger = logging.getLogger(__name__)
 
 
-class RequiresDocumentTypeMixin:
+class WithDocumentTypeMixin:
 
     DOCUMENT_TYPE: Optional[Type[Document]] = None
 

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 from pytorch_ie.core.document import Annotation, Document
 from pytorch_ie.core.hf_hub_mixin import PieTaskModuleHFHubMixin
-from pytorch_ie.core.module_mixins import RequiresDocumentTypeMixin
+from pytorch_ie.core.module_mixins import WithDocumentTypeMixin
 from pytorch_ie.core.registrable import Registrable
 
 """
@@ -133,7 +133,7 @@ class TaskModule(
     PieTaskModuleHFHubMixin,
     HyperparametersMixin,
     Registrable,
-    RequiresDocumentTypeMixin,
+    WithDocumentTypeMixin,
     Generic[
         DocumentType,
         InputEncoding,

--- a/src/pytorch_ie/documents.py
+++ b/src/pytorch_ie/documents.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, Tuple
 from typing_extensions import TypeAlias
 
 from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, MultiLabel, Span
-from pytorch_ie.core import AnnotationList, Document, annotation_field
+from pytorch_ie.core import AnnotationLayer, Document, annotation_field
 
 
 @dataclasses.dataclass
@@ -39,12 +39,12 @@ TextDocument: TypeAlias = TextBasedDocument
 
 @dataclasses.dataclass
 class DocumentWithLabel(Document):
-    label: AnnotationList[Label] = annotation_field()
+    label: AnnotationLayer[Label] = annotation_field()
 
 
 @dataclasses.dataclass
 class DocumentWithMultiLabel(Document):
-    label: AnnotationList[MultiLabel] = annotation_field()
+    label: AnnotationLayer[MultiLabel] = annotation_field()
 
 
 @dataclasses.dataclass
@@ -59,22 +59,22 @@ class TextDocumentWithMultiLabel(DocumentWithMultiLabel, TextBasedDocument):
 
 @dataclasses.dataclass
 class TextDocumentWithLabeledPartitions(TextBasedDocument):
-    labeled_partitions: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    labeled_partitions: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 
 @dataclasses.dataclass
 class TextDocumentWithSentences(TextBasedDocument):
-    sentences: AnnotationList[Span] = annotation_field(target="text")
+    sentences: AnnotationLayer[Span] = annotation_field(target="text")
 
 
 @dataclasses.dataclass
 class TextDocumentWithSpans(TextBasedDocument):
-    spans: AnnotationList[Span] = annotation_field(target="text")
+    spans: AnnotationLayer[Span] = annotation_field(target="text")
 
 
 @dataclasses.dataclass
 class TextDocumentWithLabeledSpans(TextBasedDocument):
-    labeled_spans: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    labeled_spans: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 
 @dataclasses.dataclass
@@ -93,7 +93,7 @@ class TextDocumentWithLabeledSpansAndSentences(
 
 @dataclasses.dataclass
 class TextDocumentWithLabeledSpansAndBinaryRelations(TextDocumentWithLabeledSpans):
-    binary_relations: AnnotationList[BinaryRelation] = annotation_field(target="labeled_spans")
+    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(target="labeled_spans")
 
 
 @dataclasses.dataclass
@@ -107,7 +107,7 @@ class TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions(
 
 @dataclasses.dataclass
 class TextDocumentWithSpansAndBinaryRelations(TextDocumentWithSpans):
-    binary_relations: AnnotationList[BinaryRelation] = annotation_field(target="spans")
+    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(target="spans")
 
 
 @dataclasses.dataclass

--- a/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
+++ b/src/pytorch_ie/taskmodules/transformer_re_text_classification.py
@@ -36,7 +36,7 @@ from pytorch_ie.annotations import (
     NaryRelation,
     Span,
 )
-from pytorch_ie.core import AnnotationList, Document, TaskEncoding, TaskModule
+from pytorch_ie.core import AnnotationLayer, Document, TaskEncoding, TaskModule
 from pytorch_ie.documents import (
     TextDocument,
     TextDocumentWithLabeledSpansAndBinaryRelations,
@@ -232,11 +232,11 @@ class TransformerRETextClassificationTaskModule(TaskModuleType, ChangesTokenizer
             )
             return None
 
-    def get_relation_layer(self, document: Document) -> AnnotationList[BinaryRelation]:
+    def get_relation_layer(self, document: Document) -> AnnotationLayer[BinaryRelation]:
         return document[self.relation_annotation]
 
-    def get_entity_layer(self, document: Document) -> AnnotationList[LabeledSpan]:
-        relations: AnnotationList[BinaryRelation] = self.get_relation_layer(document)
+    def get_entity_layer(self, document: Document) -> AnnotationLayer[LabeledSpan]:
+        relations: AnnotationLayer[BinaryRelation] = self.get_relation_layer(document)
         if len(relations._targets) != 1:
             raise Exception(
                 f"the relation layer is expected to target exactly one entity layer, but it has "
@@ -249,8 +249,8 @@ class TransformerRETextClassificationTaskModule(TaskModuleType, ChangesTokenizer
         entity_labels: Set[str] = set()
         relation_labels: Set[str] = set()
         for document in documents:
-            relations: AnnotationList[BinaryRelation] = self.get_relation_layer(document)
-            entities: AnnotationList[LabeledSpan] = self.get_entity_layer(document)
+            relations: AnnotationLayer[BinaryRelation] = self.get_relation_layer(document)
+            entities: AnnotationLayer[LabeledSpan] = self.get_entity_layer(document)
 
             for entity in entities:
                 entity_labels.add(entity.label)
@@ -303,8 +303,8 @@ class TransformerRETextClassificationTaskModule(TaskModuleType, ChangesTokenizer
         document: Document,
     ) -> List[BinaryRelation]:
         relation_candidates: List[BinaryRelation] = []
-        relations: AnnotationList[BinaryRelation] = self.get_relation_layer(document)
-        entities: AnnotationList[LabeledSpan] = self.get_entity_layer(document)
+        relations: AnnotationLayer[BinaryRelation] = self.get_relation_layer(document)
+        entities: AnnotationLayer[LabeledSpan] = self.get_entity_layer(document)
         arguments_to_relation = {(rel.head, rel.tail): rel for rel in relations}
         # iterate over all possible argument candidates
         for head in entities:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,16 +4,16 @@ import json
 import pytest
 
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
 from tests import FIXTURES_ROOT
 
 
 @dataclasses.dataclass
 class TestDocument(TextDocument):
-    sentences: AnnotationList[Span] = annotation_field(target="text")
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    sentences: AnnotationLayer[Span] = annotation_field(target="text")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 def example_to_doc_dict(example):

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -6,7 +6,7 @@ import pytest
 
 from pytorch_ie.core import Annotation
 from pytorch_ie.core.document import (
-    AnnotationList,
+    AnnotationLayer,
     Document,
     _contains_annotation_type,
     _get_reference_fields_and_container_types,
@@ -269,7 +269,7 @@ def test_annotation_is_attached():
     @dataclasses.dataclass
     class MyDocument(Document):
         text: str
-        words: AnnotationList[Span] = annotation_field(target="text")
+        words: AnnotationLayer[Span] = annotation_field(target="text")
 
     document = MyDocument(text="Hello world!")
     word = Span(start=0, end=5)
@@ -292,8 +292,8 @@ def test_annotation_copy():
     @dataclasses.dataclass
     class MyDocument(Document):
         text: str
-        words: AnnotationList[Span] = annotation_field(target="text")
-        attributes: AnnotationList[Attribute] = annotation_field(target="words")
+        words: AnnotationLayer[Span] = annotation_field(target="text")
+        attributes: AnnotationLayer[Attribute] = annotation_field(target="words")
 
     document = MyDocument(text="Hello world!")
     word = Span(start=0, end=5)

--- a/tests/core/test_metric.py
+++ b/tests/core/test_metric.py
@@ -4,7 +4,7 @@ from typing import Optional
 import pytest
 
 from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.core import AnnotationList, Document, DocumentMetric, annotation_field
+from pytorch_ie.core import AnnotationLayer, Document, DocumentMetric, annotation_field
 from pytorch_ie.documents import TextBasedDocument
 
 
@@ -12,7 +12,7 @@ from pytorch_ie.documents import TextBasedDocument
 def documents():
     @dataclass
     class TextDocumentWithEntities(TextBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
     # a test sentence with two entities
     doc1 = TextDocumentWithEntities(

--- a/tests/metrics/test_f1.py
+++ b/tests/metrics/test_f1.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import pytest
 
 from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextBasedDocument
 from pytorch_ie.metrics import F1Metric
 
@@ -12,7 +12,7 @@ from pytorch_ie.metrics import F1Metric
 def documents():
     @dataclass
     class TextDocumentWithEntities(TextBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
     # a test sentence with two entities
     doc1 = TextDocumentWithEntities(

--- a/tests/pipeline/test_ner_span_classification.py
+++ b/tests/pipeline/test_ner_span_classification.py
@@ -4,7 +4,7 @@ import pytest
 
 from pytorch_ie import AutoPipeline
 from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models import TransformerSpanClassificationModel
 from pytorch_ie.pipeline import Pipeline
@@ -13,7 +13,7 @@ from pytorch_ie.taskmodules import TransformerSpanClassificationTaskModule
 
 @dataclass
 class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 
 @pytest.mark.slow

--- a/tests/pipeline/test_re_generative.py
+++ b/tests/pipeline/test_re_generative.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import pytest
 
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models import TransformerSeq2SeqModel
 from pytorch_ie.pipeline import Pipeline
@@ -12,8 +12,8 @@ from pytorch_ie.taskmodules import TransformerSeq2SeqTaskModule
 
 @dataclass
 class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 @pytest.mark.slow

--- a/tests/pipeline/test_re_text_classification.py
+++ b/tests/pipeline/test_re_text_classification.py
@@ -5,7 +5,7 @@ import pytest
 
 from pytorch_ie import AutoPipeline
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models import TransformerTextClassificationModel
 from pytorch_ie.pipeline import Pipeline
@@ -14,8 +14,8 @@ from pytorch_ie.taskmodules import TransformerRETextClassificationTaskModule
 
 @dataclass
 class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 @pytest.mark.slow

--- a/tests/taskmodules/test_simple_transformer_text_classification.py
+++ b/tests/taskmodules/test_simple_transformer_text_classification.py
@@ -8,7 +8,7 @@ from transformers import BatchEncoding
 
 from pytorch_ie import SimpleTransformerTextClassificationTaskModule
 from pytorch_ie.annotations import Label
-from pytorch_ie.core import AnnotationList, Document, annotation_field
+from pytorch_ie.core import AnnotationLayer, Document, annotation_field
 
 
 def _config_to_str(cfg: Dict[str, Any]) -> str:
@@ -55,7 +55,7 @@ def test_taskmodule(unprepared_taskmodule):
 @dataclass
 class ExampleDocument(Document):
     text: str
-    label: AnnotationList[Label] = annotation_field()
+    label: AnnotationLayer[Label] = annotation_field()
 
 
 @pytest.fixture(scope="module")

--- a/tests/taskmodules/test_transformer_seq2seq.py
+++ b/tests/taskmodules/test_transformer_seq2seq.py
@@ -7,7 +7,7 @@ from transformers import BatchEncoding
 
 from pytorch_ie import TransformerSeq2SeqTaskModule
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
 
 
@@ -30,8 +30,8 @@ def test_taskmodule(taskmodule):
 
 @dataclass
 class ExampleDocument(TextDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 @pytest.fixture(scope="module")

--- a/tests/taskmodules/test_transformer_token_classification.py
+++ b/tests/taskmodules/test_transformer_token_classification.py
@@ -8,7 +8,7 @@ from transformers import BatchEncoding
 
 from pytorch_ie import TransformerTokenClassificationTaskModule
 from pytorch_ie.annotations import LabeledSpan, Span
-from pytorch_ie.core import AnnotationList, Document, annotation_field
+from pytorch_ie.core import AnnotationLayer, Document, annotation_field
 
 
 def _config_to_str(cfg: Dict[str, Any]) -> str:
@@ -58,8 +58,8 @@ def unprepared_taskmodule(config):
 @dataclass
 class ExampleDocument(Document):
     text: str
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    sentences: AnnotationList[Span] = annotation_field(target="text")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    sentences: AnnotationLayer[Span] = annotation_field(target="text")
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -4,7 +4,7 @@ import pytest
 
 from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.auto import AutoModel, AutoPipeline, AutoTaskModule
-from pytorch_ie.core import AnnotationList, TaskModule, annotation_field
+from pytorch_ie.core import AnnotationLayer, TaskModule, annotation_field
 from pytorch_ie.documents import TextDocument
 from pytorch_ie.models import TransformerSpanClassificationModel
 from pytorch_ie.taskmodules import TransformerSpanClassificationTaskModule
@@ -61,7 +61,7 @@ def test_auto_model():
 def test_auto_pipeline():
     @dataclass
     class ExampleDocument(TextDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
     pipeline = AutoPipeline.from_pretrained("pie/example-ner-spanclf-conll03")
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytest
 
 from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, Span
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.core.document import Annotation, Document, _enumerate_dependencies
 from pytorch_ie.documents import TextDocument, TokenBasedDocument
 
@@ -42,15 +42,15 @@ def test_text_document():
 def test_document_with_annotations():
     @dataclasses.dataclass
     class TestDocument(TextDocument):
-        sentences: AnnotationList[Span] = annotation_field(target="text")
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
-        label: AnnotationList[Label] = annotation_field()
+        sentences: AnnotationLayer[Span] = annotation_field(target="text")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
+        label: AnnotationLayer[Label] = annotation_field()
 
     document1 = TestDocument(text="test1")
-    assert isinstance(document1.sentences, AnnotationList)
-    assert isinstance(document1.entities, AnnotationList)
-    assert isinstance(document1.relations, AnnotationList)
+    assert isinstance(document1.sentences, AnnotationLayer)
+    assert isinstance(document1.entities, AnnotationLayer)
+    assert isinstance(document1.relations, AnnotationLayer)
     assert len(document1.sentences) == 0
     assert len(document1.entities) == 0
     assert len(document1.relations) == 0
@@ -141,10 +141,10 @@ def test_document_with_same_annotations():
         text: str
         text2: str
         text3: str
-        tokens0: AnnotationList[Span] = annotation_field(target="text")
-        tokens1: AnnotationList[Span] = annotation_field(target="text")
-        tokens2: AnnotationList[Span] = annotation_field(target="text2")
-        tokens3: AnnotationList[Span] = annotation_field(target="text3")
+        tokens0: AnnotationLayer[Span] = annotation_field(target="text")
+        tokens1: AnnotationLayer[Span] = annotation_field(target="text")
+        tokens2: AnnotationLayer[Span] = annotation_field(target="text2")
+        tokens3: AnnotationLayer[Span] = annotation_field(target="text3")
 
     doc = TestDocument(text="test1", text2="test1", text3="test2")
     start = 0
@@ -175,18 +175,18 @@ def test_document_with_same_annotations():
 def test_as_type():
     @dataclasses.dataclass
     class TestDocument1(TextDocument):
-        sentences: AnnotationList[Span] = annotation_field(target="text")
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+        sentences: AnnotationLayer[Span] = annotation_field(target="text")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
     @dataclasses.dataclass
     class TestDocument2(TextDocument):
-        sentences: AnnotationList[Span] = annotation_field(target="text")
-        ents: AnnotationList[LabeledSpan] = annotation_field(target="text")
+        sentences: AnnotationLayer[Span] = annotation_field(target="text")
+        ents: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
     @dataclasses.dataclass
     class TestDocument3(TextDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
     # create input document with "sentences" and "relations"
     document1 = TestDocument1(text="test1")
@@ -238,7 +238,7 @@ def test_enumerate_dependencies_with_circle():
 def test_annotation_list_wrong_target():
     @dataclasses.dataclass
     class TestDocument(TextDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="does_not_exist")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="does_not_exist")
 
     with pytest.raises(
         TypeError,
@@ -252,7 +252,7 @@ def test_annotation_list_wrong_target():
 def test_annotation_list():
     @dataclasses.dataclass
     class TestDocument(TextDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
     document = TestDocument(text="Entity A works at B.")
 
@@ -272,7 +272,7 @@ def test_annotation_list():
     document.entities.predictions.append(entity3)
     document.entities.predictions.append(entity4)
 
-    assert isinstance(document.entities, AnnotationList)
+    assert isinstance(document.entities, AnnotationLayer)
     assert len(document.entities) == 2
     assert document.entities[0] == entity1
     assert document.entities[1] == entity2
@@ -307,12 +307,12 @@ def test_annotation_list():
 def test_annotation_list_with_multiple_targets():
     @dataclasses.dataclass
     class TestDocument(TextDocument):
-        entities1: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        entities2: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations: AnnotationList[BinaryRelation] = annotation_field(
+        entities1: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        entities2: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        relations: AnnotationLayer[BinaryRelation] = annotation_field(
             targets=["entities1", "entities2"]
         )
-        label: AnnotationList[Label] = annotation_field()
+        label: AnnotationLayer[Label] = annotation_field()
 
     doc = TestDocument(text="test1")
 
@@ -386,10 +386,10 @@ def test_annotation_list_with_named_targets():
     class TestDocument(Document):
         texta: str
         textb: str
-        entities1: AnnotationList[LabeledSpan] = annotation_field(target="texta")
-        entities2: AnnotationList[LabeledSpan] = annotation_field(target="textb")
+        entities1: AnnotationLayer[LabeledSpan] = annotation_field(target="texta")
+        entities2: AnnotationLayer[LabeledSpan] = annotation_field(target="textb")
         # note that the entries in targets do not follow the order of DoubleTextSpan.TARGET_NAMES
-        crossrefs: AnnotationList[DoubleTextSpan] = annotation_field(
+        crossrefs: AnnotationLayer[DoubleTextSpan] = annotation_field(
             named_targets={"text2": "textb", "text1": "texta"}
         )
 
@@ -446,7 +446,7 @@ def test_annotation_list_with_named_targets_mismatch_error():
     @dataclasses.dataclass
     class TestDocument(Document):
         text: str
-        entities1: AnnotationList[TextSpan] = annotation_field(named_targets={"textx": "text"})
+        entities1: AnnotationLayer[TextSpan] = annotation_field(named_targets={"textx": "text"})
 
     with pytest.raises(
         TypeError,
@@ -461,17 +461,15 @@ def test_annotation_list_with_missing_target_names():
         texta: str
         textb: str
         # note that the entries in targets do not follow the order of DoubleTextSpan.TARGET_NAMES
-        crossrefs: AnnotationList[DoubleTextSpan] = annotation_field(targets=["textb", "texta"])
+        crossrefs: AnnotationLayer[DoubleTextSpan] = annotation_field(targets=["textb", "texta"])
 
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
-            "A target name mapping is required for AnnotationLists containing Annotations with TARGET_NAMES, but "
-            'AnnotationList "crossrefs" has no target_names. You should pass the named_targets dict containing the '
-            "following keys (see Annotation \"DoubleTextSpan\") to annotation_field: ('text1', 'text2')"
-        ),
-    ):
+    with pytest.raises(TypeError) as excinfo:
         doc = TestDocument(texta="text1", textb="text2")
+    assert str(excinfo.value) == (
+        "A target name mapping is required for AnnotationLayers containing Annotations with TARGET_NAMES, but "
+        'AnnotationLayer "crossrefs" has no target_names. You should pass the named_targets dict containing the '
+        "following keys (see Annotation \"DoubleTextSpan\") to annotation_field: ('text1', 'text2')"
+    )
 
 
 def test_annotation_list_number_of_targets_mismatch_error():
@@ -479,7 +477,7 @@ def test_annotation_list_number_of_targets_mismatch_error():
     class TestDocument(Document):
         texta: str
         textb: str
-        crossrefs: AnnotationList[DoubleTextSpan] = annotation_field(target="texta")
+        crossrefs: AnnotationLayer[DoubleTextSpan] = annotation_field(target="texta")
 
     with pytest.raises(
         TypeError,
@@ -495,13 +493,13 @@ def test_annotation_list_artificial_root_error():
     @dataclasses.dataclass
     class TestDocument(Document):
         text: str
-        _artificial_root: AnnotationList[LabeledSpan] = annotation_field(target="text")
+        _artificial_root: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
     with pytest.raises(
         ValueError,
         match=re.escape(
             'Failed to add the "_artificial_root" node to the annotation graph because it already exists. Note '
-            "that AnnotationList entries with that name are not allowed."
+            "that AnnotationLayer entries with that name are not allowed."
         ),
     ):
         doc = TestDocument(text="text1")
@@ -511,10 +509,10 @@ def test_annotation_list_targets():
     @dataclasses.dataclass
     class TestDocument(Document):
         text: str
-        entities1: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        entities2: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations1: AnnotationList[BinaryRelation] = annotation_field(target="entities1")
-        relations2: AnnotationList[BinaryRelation] = annotation_field(
+        entities1: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        entities2: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        relations1: AnnotationLayer[BinaryRelation] = annotation_field(target="entities1")
+        relations2: AnnotationLayer[BinaryRelation] = annotation_field(
             targets=["entities1", "entities2"]
         )
 
@@ -584,7 +582,7 @@ def test_annotation_compare():
     # assert that nothing changes when adding the annotation to a document
     @dataclasses.dataclass
     class TestDocument(TextDocument):
-        annotations: AnnotationList[TestAnnotation] = annotation_field(target="text")
+        annotations: AnnotationLayer[TestAnnotation] = annotation_field(target="text")
 
     id0 = annotation0._id
     hash0 = hash(annotation0)
@@ -619,13 +617,13 @@ class Attribute(Annotation):
 def text_document():
     @dataclasses.dataclass
     class TextBasedDocumentWithEntitiesRelationsAndRelationAttributes(TextDocument):
-        entities1: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        entities2: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations: AnnotationList[BinaryRelation] = annotation_field(
+        entities1: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        entities2: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        relations: AnnotationLayer[BinaryRelation] = annotation_field(
             targets=["entities1", "entities2"]
         )
-        labels: AnnotationList[Label] = annotation_field()
-        relation_attributes: AnnotationList[Attribute] = annotation_field(target="relations")
+        labels: AnnotationLayer[Label] = annotation_field()
+        relation_attributes: AnnotationLayer[Attribute] = annotation_field(target="relations")
 
     doc1 = TextBasedDocumentWithEntitiesRelationsAndRelationAttributes(text="Hello World!")
     e1 = LabeledSpan(0, 5, "word1")
@@ -660,13 +658,13 @@ def test_document_extend_from_other_wrong_override_annotation_mapping(text_docum
 def test_document_extend_from_other_override(text_document):
     @dataclasses.dataclass
     class TestDocument2(TokenBasedDocument):
-        entities1: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-        entities2: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-        relations: AnnotationList[BinaryRelation] = annotation_field(
+        entities1: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+        entities2: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+        relations: AnnotationLayer[BinaryRelation] = annotation_field(
             targets=["entities1", "entities2"]
         )
-        labels: AnnotationList[Label] = annotation_field()
-        relation_attributes: AnnotationList[Attribute] = annotation_field(target="relations")
+        labels: AnnotationLayer[Label] = annotation_field()
+        relation_attributes: AnnotationLayer[Attribute] = annotation_field(target="relations")
 
     token_document = TestDocument2(tokens=("Hello", "World", "!"))
     # create new entities


### PR DESCRIPTION
This PR renames:
 - `AnnotationList` to `AnnotationLayer`, and
 - `RequiresDocumentTypeMixin` to `WithDocumentTypeMixin`.

Note: The classes are still available via the old names as aliases.