### PR TITLE
implement `PreparableMixin`

### DIFF
--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -11,6 +11,8 @@ from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import SoftTemporaryDirectory, validate_hf_hub_args
 
+from pytorch_ie.core.module_mixins import PreparableMixin
+
 logger = logging.getLogger(__name__)
 
 MODEL_CONFIG_NAME = CONFIG_NAME
@@ -397,7 +399,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         return model
 
 
-class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
+class PieTaskModuleHFHubMixin(PieBaseHFHubMixin, PreparableMixin):
     config_name = TASKMODULE_CONFIG_NAME
     config_type_key = TASKMODULE_CONFIG_TYPE_KEY
 
@@ -406,9 +408,6 @@ class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
 
     def _save_pretrained(self, save_directory):
         return None
-
-    def post_prepare(self) -> None:
-        pass
 
     @classmethod
     def _from_pretrained(

--- a/src/pytorch_ie/core/hf_hub_mixin.py
+++ b/src/pytorch_ie/core/hf_hub_mixin.py
@@ -11,8 +11,6 @@ from huggingface_hub.file_download import hf_hub_download
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import SoftTemporaryDirectory, validate_hf_hub_args
 
-from pytorch_ie.core.module_mixins import PreparableMixin
-
 logger = logging.getLogger(__name__)
 
 MODEL_CONFIG_NAME = CONFIG_NAME
@@ -399,7 +397,7 @@ class PieModelHFHubMixin(PieBaseHFHubMixin):
         return model
 
 
-class PieTaskModuleHFHubMixin(PieBaseHFHubMixin, PreparableMixin):
+class PieTaskModuleHFHubMixin(PieBaseHFHubMixin):
     config_name = TASKMODULE_CONFIG_NAME
     config_type_key = TASKMODULE_CONFIG_TYPE_KEY
 
@@ -432,6 +430,4 @@ class PieTaskModuleHFHubMixin(PieBaseHFHubMixin, PreparableMixin):
             config.pop(cls.config_type_key)
 
         taskmodule = cls(**config)
-        taskmodule.post_prepare()
-
         return taskmodule

--- a/src/pytorch_ie/core/module_mixins.py
+++ b/src/pytorch_ie/core/module_mixins.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Type
+from typing import List, Optional, Type
 
 from pytorch_ie.core.document import Document
 
@@ -36,3 +36,64 @@ class WithDocumentTypeMixin:
             )
 
         return dataset
+
+
+class PreparableMixin:
+    # list of attribute names that need to be set by _prepare()
+    PREPARED_ATTRIBUTES: List[str] = []
+
+    @property
+    def is_prepared(self):
+        """
+        Returns True, iff all attributes listed in PREPARED_ATTRIBUTES are set.
+        Note: Attributes set to None are not considered to be prepared!
+        """
+        return all(
+            getattr(self, attribute, None) is not None for attribute in self.PREPARED_ATTRIBUTES
+        )
+
+    @property
+    def prepared_attributes(self):
+        if not self.is_prepared:
+            raise Exception("The module is not prepared.")
+        return {param: getattr(self, param) for param in self.PREPARED_ATTRIBUTES}
+
+    def _prepare(self, *args, **kwargs):
+        """
+        This method needs to set all attributes listed in PREPARED_ATTRIBUTES.
+        """
+        pass
+
+    def _post_prepare(self):
+        """
+        Any code to do further one-time setup, but that requires the prepared attributes.
+        """
+        pass
+
+    def _assert_is_prepared(self, msg: Optional[str] = None):
+        if not self.is_prepared:
+            attributes_not_prepared = [
+                param for param in self.PREPARED_ATTRIBUTES if getattr(self, param, None) is None
+            ]
+            raise Exception(
+                f"{msg or ''} Required attributes that are not set: {str(attributes_not_prepared)}"
+            )
+
+    def post_prepare(self):
+        self._assert_is_prepared()
+        self._post_prepare()
+
+    def prepare(self, *args, **kwargs) -> None:
+        if self.is_prepared:
+            if len(self.PREPARED_ATTRIBUTES) > 0:
+                msg = "The module is already prepared, do not prepare again."
+                for k, v in self.prepared_attributes.items():
+                    msg += f"\n{k} = {str(v)}"
+                logger.warning(msg)
+        else:
+            self._prepare(*args, **kwargs)
+            self._assert_is_prepared(
+                msg="_prepare() was called, but the module is not prepared."
+            )
+        self._post_prepare()
+        return None

--- a/src/pytorch_ie/core/module_mixins.py
+++ b/src/pytorch_ie/core/module_mixins.py
@@ -92,8 +92,6 @@ class PreparableMixin:
                 logger.warning(msg)
         else:
             self._prepare(*args, **kwargs)
-            self._assert_is_prepared(
-                msg="_prepare() was called, but the module is not prepared."
-            )
+            self._assert_is_prepared(msg="_prepare() was called, but the module is not prepared.")
         self._post_prepare()
         return None

--- a/src/pytorch_ie/core/module_mixins.py
+++ b/src/pytorch_ie/core/module_mixins.py
@@ -70,7 +70,7 @@ class PreparableMixin:
         """
         pass
 
-    def _assert_is_prepared(self, msg: Optional[str] = None):
+    def assert_is_prepared(self, msg: Optional[str] = None):
         if not self.is_prepared:
             attributes_not_prepared = [
                 param for param in self.PREPARED_ATTRIBUTES if getattr(self, param, None) is None
@@ -80,18 +80,20 @@ class PreparableMixin:
             )
 
     def post_prepare(self):
-        self._assert_is_prepared()
+        self.assert_is_prepared()
         self._post_prepare()
 
     def prepare(self, *args, **kwargs) -> None:
         if self.is_prepared:
             if len(self.PREPARED_ATTRIBUTES) > 0:
-                msg = "The module is already prepared, do not prepare again."
+                msg = f"The {self.__class__.__name__} is already prepared, do not prepare again."
                 for k, v in self.prepared_attributes.items():
                     msg += f"\n{k} = {str(v)}"
                 logger.warning(msg)
         else:
             self._prepare(*args, **kwargs)
-            self._assert_is_prepared(msg="_prepare() was called, but the module is not prepared.")
+            self.assert_is_prepared(
+                msg=f"_prepare() was called, but the {self.__class__.__name__} is not prepared."
+            )
         self._post_prepare()
         return None

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 from pytorch_ie.core.document import Annotation, Document
 from pytorch_ie.core.hf_hub_mixin import PieTaskModuleHFHubMixin
-from pytorch_ie.core.module_mixins import WithDocumentTypeMixin, RequiresDocumentTypeMixin
+from pytorch_ie.core.module_mixins import PreparableMixin, WithDocumentTypeMixin
 from pytorch_ie.core.registrable import Registrable
 
 """

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -134,6 +134,7 @@ class TaskModule(
     HyperparametersMixin,
     Registrable,
     WithDocumentTypeMixin,
+    PreparableMixin,
     Generic[
         DocumentType,
         InputEncoding,
@@ -155,6 +156,16 @@ class TaskModule(
         # add all prepared attributes
         config.update(self.prepared_attributes)
         return config
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        *args,
+        **kwargs,
+    ):
+        taskmodule: TaskModule = super()._from_pretrained(*args, **kwargs)
+        taskmodule.post_prepare()
+        return taskmodule
 
     def batch_encode(
         self,

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -134,7 +134,6 @@ class TaskModule(
     HyperparametersMixin,
     Registrable,
     WithDocumentTypeMixin,
-    PreparableMixin,
     Generic[
         DocumentType,
         InputEncoding,
@@ -144,8 +143,6 @@ class TaskModule(
         TaskOutput,
     ],
 ):
-    PREPARED_ATTRIBUTES: List[str] = []
-
     def __init__(self, encode_document_batch_size: Optional[int] = None, **kwargs):
         super().__init__(**kwargs)
         self.encode_document_batch_size = encode_document_batch_size
@@ -158,16 +155,6 @@ class TaskModule(
         # add all prepared attributes
         config.update(self.prepared_attributes)
         return config
-
-    @classmethod
-    def _from_pretrained(
-        cls,
-        *args,
-        **kwargs,
-    ):
-        taskmodule: TaskModule = super()._from_pretrained(*args, **kwargs)
-        taskmodule._post_prepare()
-        return taskmodule
 
     def batch_encode(
         self,

--- a/src/pytorch_ie/core/taskmodule.py
+++ b/src/pytorch_ie/core/taskmodule.py
@@ -233,6 +233,8 @@ class TaskModule(
         TaskEncodingDataset[TaskEncoding[DocumentType, InputEncoding, TargetEncoding]],
         IterableTaskEncodingDataset[TaskEncoding[DocumentType, InputEncoding, TargetEncoding]],
     ]:
+        self.assert_is_prepared()
+
         # backwards compatibility
         if as_task_encoding_sequence is None:
             as_task_encoding_sequence = not encode_target


### PR DESCRIPTION
This PR outsources code related to module preparation from the `TaskModule` into a `PreparableMixin` class. It also fixes minor preparation logic issues and ensures that a taskmodule is prepared when calling `encode()`.