### PR TITLE
re-arrange exports

### DIFF
--- a/src/pytorch_ie/__init__.py
+++ b/src/pytorch_ie/__init__.py
@@ -1,6 +1,5 @@
 # flake8: noqa
 
 from pytorch_ie.auto import AutoModel, AutoPipeline, AutoTaskModule
-from pytorch_ie.models import *
+from pytorch_ie.core import *
 from pytorch_ie.pipeline import Pipeline
-from pytorch_ie.taskmodules import *

--- a/src/pytorch_ie/taskmodules/__init__.py
+++ b/src/pytorch_ie/taskmodules/__init__.py
@@ -4,3 +4,12 @@ from .transformer_seq2seq import TransformerSeq2SeqTaskModule
 from .transformer_span_classification import TransformerSpanClassificationTaskModule
 from .transformer_text_classification import TransformerTextClassificationTaskModule
 from .transformer_token_classification import TransformerTokenClassificationTaskModule
+
+__all__ = [
+    "SimpleTransformerTextClassificationTaskModule",
+    "TransformerRETextClassificationTaskModule",
+    "TransformerSeq2SeqTaskModule",
+    "TransformerSpanClassificationTaskModule",
+    "TransformerTextClassificationTaskModule",
+    "TransformerTokenClassificationTaskModule",
+]

--- a/tests/models/test_transformer_seq2seq.py
+++ b/tests/models/test_transformer_seq2seq.py
@@ -4,7 +4,7 @@ import transformers
 from transformers import BatchEncoding
 from transformers.modeling_outputs import Seq2SeqLMOutput
 
-from pytorch_ie import TransformerSeq2SeqModel
+from pytorch_ie.models import TransformerSeq2SeqModel
 
 LOSS = torch.rand(1).to(dtype=torch.float)
 # a batch with one entry: 10 tokens from a 100-token vocabulary

--- a/tests/models/test_transformer_span_classification.py
+++ b/tests/models/test_transformer_span_classification.py
@@ -3,10 +3,8 @@ import torch
 import transformers
 from transformers.modeling_outputs import BaseModelOutputWithPooling
 
-from pytorch_ie.models.transformer_span_classification import TransformerSpanClassificationModel
-from pytorch_ie.taskmodules.transformer_span_classification import (
-    TransformerSpanClassificationTaskModule,
-)
+from pytorch_ie.models import TransformerSpanClassificationModel
+from pytorch_ie.taskmodules import TransformerSpanClassificationTaskModule
 
 
 @pytest.fixture(scope="module")

--- a/tests/taskmodules/test_simple_transformer_text_classification.py
+++ b/tests/taskmodules/test_simple_transformer_text_classification.py
@@ -6,9 +6,9 @@ import pytest
 import torch
 from transformers import BatchEncoding
 
-from pytorch_ie import SimpleTransformerTextClassificationTaskModule
+from pytorch_ie import AnnotationLayer, Document, annotation_field
 from pytorch_ie.annotations import Label
-from pytorch_ie.core import AnnotationLayer, Document, annotation_field
+from pytorch_ie.taskmodules import SimpleTransformerTextClassificationTaskModule
 
 
 def _config_to_str(cfg: Dict[str, Any]) -> str:

--- a/tests/taskmodules/test_transformer_re_text_classification.py
+++ b/tests/taskmodules/test_transformer_re_text_classification.py
@@ -5,7 +5,7 @@ import numpy
 import pytest
 import torch
 
-from pytorch_ie import TransformerRETextClassificationTaskModule
+from pytorch_ie.taskmodules import TransformerRETextClassificationTaskModule
 
 
 def _config_to_str(cfg: Dict[str, Any]) -> str:

--- a/tests/taskmodules/test_transformer_seq2seq.py
+++ b/tests/taskmodules/test_transformer_seq2seq.py
@@ -5,10 +5,10 @@ import pytest
 import torch
 from transformers import BatchEncoding
 
-from pytorch_ie import TransformerSeq2SeqTaskModule
+from pytorch_ie import AnnotationLayer, annotation_field
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import AnnotationLayer, annotation_field
 from pytorch_ie.documents import TextDocument
+from pytorch_ie.taskmodules import TransformerSeq2SeqTaskModule
 
 
 @pytest.fixture(scope="module")

--- a/tests/taskmodules/test_transformer_span_classification.py
+++ b/tests/taskmodules/test_transformer_span_classification.py
@@ -2,10 +2,8 @@ import numpy
 import pytest
 import torch
 
-from pytorch_ie.core import TaskModule
-from pytorch_ie.taskmodules.transformer_span_classification import (
-    TransformerSpanClassificationTaskModule,
-)
+from pytorch_ie import TaskModule
+from pytorch_ie.taskmodules import TransformerSpanClassificationTaskModule
 
 
 @pytest.fixture(scope="module")

--- a/tests/taskmodules/test_transformer_token_classification.py
+++ b/tests/taskmodules/test_transformer_token_classification.py
@@ -6,9 +6,9 @@ import pytest
 import torch
 from transformers import BatchEncoding
 
-from pytorch_ie import TransformerTokenClassificationTaskModule
+from pytorch_ie import AnnotationLayer, Document, annotation_field
 from pytorch_ie.annotations import LabeledSpan, Span
-from pytorch_ie.core import AnnotationLayer, Document, annotation_field
+from pytorch_ie.taskmodules import TransformerTokenClassificationTaskModule
 
 
 def _config_to_str(cfg: Dict[str, Any]) -> str:


### PR DESCRIPTION
Changes:
 - export everything from `core`
 - do not directly export anything from `models` and `taskmodules` anymore (to align with all other "implementations", i.e. `documents`, `annotations`, and `metrics`)

TODO:
 - [x] add description
 - [x] test usage in other PIE projects: https://github.com/ArneBinder/pie-datasets, https://github.com/ArneBinder/pie-models